### PR TITLE
Normalize decimal display for batting statistics

### DIFF
--- a/app/R/analysis.R
+++ b/app/R/analysis.R
@@ -12,6 +12,17 @@ format_stat_value <- function(x) {
   )
 }
 
+#' Format percentage values consistently
+#' @param x Numeric percentage value
+#' @return Formatted percentage string like "12.3%"
+format_percentage <- function(x) {
+  case_when(
+    is.na(x) | is.null(x) ~ "N/A",
+    is.numeric(x) ~ sprintf("%.1f%%", x),
+    TRUE ~ as.character(x)
+  )
+}
+
 #' Get analysis persona prompt using tidyverse
 #' @param mode Analysis mode string
 #' @return Persona prompt text
@@ -139,9 +150,9 @@ build_hitter_prompt <- function(player_name, hitter_data) {
     str_glue("AVG: {format_stat_value(data$AVG_cur)}  Last 3 Years: {format_stat_value(data$AVG_l3)}  Diff: {format_stat_value(data$AVG_diff)}"),
     str_glue("OBP: {format_stat_value(data$OBP_cur)}  Last 3 Years: {format_stat_value(data$OBP_l3)}  Diff: {format_stat_value(data$OBP_diff)}"),
     str_glue("SLG: {format_stat_value(data$SLG_cur)}  Last 3 Years: {format_stat_value(data$SLG_l3)}  Diff: {format_stat_value(data$SLG_diff)}"),
-    str_glue("K%: {format_stat_value(data$K_pct_cur)}  Last 3 Years: {format_stat_value(data$K_pct_l3)}  Diff: {format_stat_value(data$K_pct_diff)}"),
-    str_glue("BB%: {format_stat_value(data$BB_pct_cur)}  Last 3 Years: {format_stat_value(data$BB_pct_l3)}  Diff: {format_stat_value(data$BB_pct_diff)}"),
-    str_glue("Barrel%: {format_stat_value(data$Barrel_pct_cur)}  Last 3 Years: {format_stat_value(data$Barrel_pct_l3)}  Diff: {format_stat_value(data$Barrel_pct_diff)}"),
+    str_glue("K%: {format_percentage(data$K_pct_cur)}  Last 3 Years: {format_percentage(data$K_pct_l3)}  Diff: {format_percentage(data$K_pct_diff)}"),
+    str_glue("BB%: {format_percentage(data$BB_pct_cur)}  Last 3 Years: {format_percentage(data$BB_pct_l3)}  Diff: {format_percentage(data$BB_pct_diff)}"),
+    str_glue("Barrel%: {format_percentage(data$Barrel_pct_cur)}  Last 3 Years: {format_percentage(data$Barrel_pct_l3)}  Diff: {format_percentage(data$Barrel_pct_diff)}"),
     str_glue("BABIP: {format_stat_value(data$BABIP_cur)}  Last 3 Years: {format_stat_value(data$BABIP_l3)}  Diff: {format_stat_value(data$BABIP_diff)}"),
     str_glue("wOBA: {format_stat_value(data$wOBA_cur)}  Last 3 Years: {format_stat_value(data$wOBA_l3)}  Diff: {format_stat_value(data$wOBA_diff)}"),
     str_glue("xwOBA: {format_stat_value(data$xwOBA_cur)}  Last 3 Years: {format_stat_value(data$xwOBA_l3)}  Diff: {format_stat_value(data$xwOBA_diff)}"),
@@ -191,13 +202,13 @@ build_pitcher_prompt <- function(player_name, pitcher_data) {
     str_glue("ERA: {format_stat_value(data$era_cur)}  Last 3 Years: {format_stat_value(data$era_l3)}  Diff: {format_stat_value(data$era_diff)}"),
     str_glue("xERA: {format_stat_value(data$xera_cur)}  Last 3 Years: {format_stat_value(data$xera_l3)}  Diff: {format_stat_value(data$xera_diff)}"),
     str_glue("BABIP: {format_stat_value(data$babip_cur)}  Last 3 Years: {format_stat_value(data$babip_l3)}  Diff: {format_stat_value(data$babip_diff)}"),
-    str_glue("Barrel Rate: {format_stat_value(data$barrel_percent_cur)}%  Last 3 Years: {format_stat_value(data$barrel_percent_l3)}%  Diff: {format_stat_value(data$barrel_percent_diff)}%"),
-    str_glue("Strikeout Rate (K%): {format_stat_value(data$k_percent_cur)}%  Last 3 Years: {format_stat_value(data$k_percent_l3)}%  Diff: {format_stat_value(data$k_percent_diff)}%"),
-    str_glue("Called Strike & Whiff Rate (CSW%): {format_stat_value(data$csw_percent_cur)}%  Last 3 Years: {format_stat_value(data$csw_percent_l3)}%  Diff: {format_stat_value(data$csw_percent_diff)}%"),
-    str_glue("Outside Zone Swing Rate (O-Swing%): {format_stat_value(data$o_swing_percent_cur)}%  Last 3 Years: {format_stat_value(data$o_swing_percent_l3)}%  Diff: {format_stat_value(data$o_swing_percent_diff)}%"),
-    str_glue("Walk Rate (BB%): {format_stat_value(data$bb_percent_cur)}%  Last 3 Years: {format_stat_value(data$bb_percent_l3)}%  Diff: {format_stat_value(data$bb_percent_diff)}%"),
-    str_glue("K-BB%: {format_stat_value(data$k_minus_bb_percent_cur)}%  Last 3 Years: {format_stat_value(data$k_minus_bb_percent_l3)}%  Diff: {format_stat_value(data$k_minus_bb_percent_diff)}%"),
-    str_glue("LOB% (Left-on-base rate): {format_stat_value(data$lob_percent_cur)}%  Last 3 Years: {format_stat_value(data$lob_percent_l3)}%  Diff: {format_stat_value(data$lob_percent_diff)}%")
+    str_glue("Barrel Rate: {format_percentage(data$barrel_percent_cur)}  Last 3 Years: {format_percentage(data$barrel_percent_l3)}  Diff: {format_percentage(data$barrel_percent_diff)}"),
+    str_glue("Strikeout Rate (K%): {format_percentage(data$k_percent_cur)}  Last 3 Years: {format_percentage(data$k_percent_l3)}  Diff: {format_percentage(data$k_percent_diff)}"),
+    str_glue("Called Strike & Whiff Rate (CSW%): {format_percentage(data$csw_percent_cur)}  Last 3 Years: {format_percentage(data$csw_percent_l3)}  Diff: {format_percentage(data$csw_percent_diff)}"),
+    str_glue("Outside Zone Swing Rate (O-Swing%): {format_percentage(data$o_swing_percent_cur)}  Last 3 Years: {format_percentage(data$o_swing_percent_l3)}  Diff: {format_percentage(data$o_swing_percent_diff)}"),
+    str_glue("Walk Rate (BB%): {format_percentage(data$bb_percent_cur)}  Last 3 Years: {format_percentage(data$bb_percent_l3)}  Diff: {format_percentage(data$bb_percent_diff)}"),
+    str_glue("K-BB%: {format_percentage(data$k_minus_bb_percent_cur)}  Last 3 Years: {format_percentage(data$k_minus_bb_percent_l3)}  Diff: {format_percentage(data$k_minus_bb_percent_diff)}"),
+    str_glue("LOB% (Left-on-base rate): {format_percentage(data$lob_percent_cur)}  Last 3 Years: {format_percentage(data$lob_percent_l3)}  Diff: {format_percentage(data$lob_percent_diff)}")
   )
 
   notes_section <- c(

--- a/app/R/analysis.R
+++ b/app/R/analysis.R
@@ -18,7 +18,7 @@ format_stat_value <- function(x) {
 format_percentage <- function(x) {
   case_when(
     is.na(x) | is.null(x) ~ "N/A",
-    is.numeric(x) ~ sprintf("%.1f%%", x),
+    is.numeric(x) ~ sub("^(-?)0+([0-9])", "\\1\\2", sprintf("%.1f%%", x)),
     TRUE ~ as.character(x)
   )
 }

--- a/app/R/analysis.R
+++ b/app/R/analysis.R
@@ -6,6 +6,7 @@
 format_stat_value <- function(x) {
   case_when(
     is.na(x) | is.null(x) ~ "N/A",
+    is.numeric(x) & abs(x) < 1 ~ sub("^(-?)0", "\\1", sprintf("%.3f", x)),
     is.numeric(x) ~ as.character(round(x, 3)),
     TRUE ~ as.character(x)
   )

--- a/app/R/analysis.R
+++ b/app/R/analysis.R
@@ -23,6 +23,17 @@ format_percentage <- function(x) {
   )
 }
 
+#' Format ERA-style values with two decimals
+#' @param x Numeric ERA value
+#' @return Formatted string like "1.23"
+format_era <- function(x) {
+  case_when(
+    is.na(x) | is.null(x) ~ "N/A",
+    is.numeric(x) ~ sprintf("%.2f", x),
+    TRUE ~ as.character(x)
+  )
+}
+
 #' Get analysis persona prompt using tidyverse
 #' @param mode Analysis mode string
 #' @return Persona prompt text
@@ -199,8 +210,8 @@ build_pitcher_prompt <- function(player_name, pitcher_data) {
   )
 
   metrics_section <- c(
-    str_glue("ERA: {format_stat_value(data$era_cur)}  Last 3 Years: {format_stat_value(data$era_l3)}  Diff: {format_stat_value(data$era_diff)}"),
-    str_glue("xERA: {format_stat_value(data$xera_cur)}  Last 3 Years: {format_stat_value(data$xera_l3)}  Diff: {format_stat_value(data$xera_diff)}"),
+    str_glue("ERA: {format_era(data$era_cur)}  Last 3 Years: {format_era(data$era_l3)}  Diff: {format_era(data$era_diff)}"),
+    str_glue("xERA: {format_era(data$xera_cur)}  Last 3 Years: {format_era(data$xera_l3)}  Diff: {format_era(data$xera_diff)}"),
     str_glue("BABIP: {format_stat_value(data$babip_cur)}  Last 3 Years: {format_stat_value(data$babip_l3)}  Diff: {format_stat_value(data$babip_diff)}"),
     str_glue("Barrel Rate: {format_percentage(data$barrel_percent_cur)}  Last 3 Years: {format_percentage(data$barrel_percent_l3)}  Diff: {format_percentage(data$barrel_percent_diff)}"),
     str_glue("Strikeout Rate (K%): {format_percentage(data$k_percent_cur)}  Last 3 Years: {format_percentage(data$k_percent_l3)}  Diff: {format_percentage(data$k_percent_diff)}"),

--- a/app/server.R
+++ b/app/server.R
@@ -72,8 +72,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
         list(label = "AVG", value = format_stat_value(player_data$AVG_cur)),
         list(label = "OBP", value = format_stat_value(player_data$OBP_cur)),
         list(label = "SLG", value = format_stat_value(player_data$SLG_cur)),
-        list(label = "K%", value = paste0(round(player_data$K_pct_cur, 1), "%")),
-        list(label = "BB%", value = paste0(round(player_data$BB_pct_cur, 1), "%")),
+        list(label = "K%", value = format_percentage(player_data$K_pct_cur)),
+        list(label = "BB%", value = format_percentage(player_data$BB_pct_cur)),
         list(label = "wOBA", value = format_stat_value(player_data$wOBA_cur))
       )
       
@@ -93,10 +93,10 @@ generate_player_stat_line <- function(player_id, baseball_data) {
       stats <- list(
         list(label = "ERA", value = sprintf("%.2f", player_data$era_cur)),
         list(label = "xERA", value = sprintf("%.2f", player_data$xera_cur)),
-        list(label = "K%", value = paste0(round(player_data$k_percent_cur, 1), "%")),
-        list(label = "BB%", value = paste0(round(player_data$bb_percent_cur, 1), "%")),
+        list(label = "K%", value = format_percentage(player_data$k_percent_cur)),
+        list(label = "BB%", value = format_percentage(player_data$bb_percent_cur)),
         list(label = "BABIP", value = babip_val),
-        list(label = "LOB%", value = paste0(round(player_data$lob_percent_cur, 1), "%"))
+        list(label = "LOB%", value = format_percentage(player_data$lob_percent_cur))
       )
       
       return(list(
@@ -958,8 +958,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
           list(label = "AVG", value = format_stat_value(player_data$AVG_cur)),
           list(label = "OBP", value = format_stat_value(player_data$OBP_cur)),
           list(label = "SLG", value = format_stat_value(player_data$SLG_cur)),
-          list(label = "K%", value = paste0(format_stat_value(player_data$K_pct_cur), "%")),
-          list(label = "BB%", value = paste0(format_stat_value(player_data$BB_pct_cur), "%")),
+          list(label = "K%", value = format_percentage(player_data$K_pct_cur)),
+          list(label = "BB%", value = format_percentage(player_data$BB_pct_cur)),
           list(label = "wOBA", value = format_stat_value(player_data$wOBA_cur))
         )
         
@@ -979,10 +979,10 @@ generate_player_stat_line <- function(player_id, baseball_data) {
         stats <- list(
           list(label = "ERA", value = format_stat_value(player_data$era_cur)),
           list(label = "xERA", value = format_stat_value(player_data$xera_cur)),
-          list(label = "K%", value = paste0(format_stat_value(player_data$k_percent_cur), "%")),
-          list(label = "BB%", value = paste0(format_stat_value(player_data$bb_percent_cur), "%")),
+          list(label = "K%", value = format_percentage(player_data$k_percent_cur)),
+          list(label = "BB%", value = format_percentage(player_data$bb_percent_cur)),
           list(label = "BABIP", value = format_stat_value(player_data$babip_cur)),
-          list(label = "LOB%", value = paste0(format_stat_value(player_data$lob_percent_cur), "%"))
+          list(label = "LOB%", value = format_percentage(player_data$lob_percent_cur))
         )
         
         return(list(

--- a/app/server.R
+++ b/app/server.R
@@ -68,19 +68,13 @@ generate_player_stat_line <- function(player_id, baseball_data) {
     player_data <- baseball_data$hitters %>% filter(PlayerId == actual_player_id)
     
     if (nrow(player_data) > 0) {
-      # Simple formatting - remove leading zeros from batting averages
-      avg_val <- sprintf("%.3f", player_data$AVG_cur) %>% sub("^0\\.", ".", .)
-      obp_val <- sprintf("%.3f", player_data$OBP_cur) %>% sub("^0\\.", ".", .)
-      slg_val <- sprintf("%.3f", player_data$SLG_cur) %>% sub("^0\\.", ".", .)
-      woba_val <- sprintf("%.3f", player_data$wOBA_cur) %>% sub("^0\\.", ".", .)
-      
       stats <- list(
-        list(label = "AVG", value = avg_val),
-        list(label = "OBP", value = obp_val),
-        list(label = "SLG", value = slg_val),
+        list(label = "AVG", value = format_stat_value(player_data$AVG_cur)),
+        list(label = "OBP", value = format_stat_value(player_data$OBP_cur)),
+        list(label = "SLG", value = format_stat_value(player_data$SLG_cur)),
         list(label = "K%", value = paste0(round(player_data$K_pct_cur, 1), "%")),
         list(label = "BB%", value = paste0(round(player_data$BB_pct_cur, 1), "%")),
-        list(label = "wOBA", value = woba_val)
+        list(label = "wOBA", value = format_stat_value(player_data$wOBA_cur))
       )
       
       return(list(

--- a/app/server.R
+++ b/app/server.R
@@ -91,8 +91,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
       babip_val <- sprintf("%.3f", player_data$babip_cur) %>% sub("^0\\.", ".", .)
       
       stats <- list(
-        list(label = "ERA", value = sprintf("%.2f", player_data$era_cur)),
-        list(label = "xERA", value = sprintf("%.2f", player_data$xera_cur)),
+        list(label = "ERA", value = format_era(player_data$era_cur)),
+        list(label = "xERA", value = format_era(player_data$xera_cur)),
         list(label = "K%", value = format_percentage(player_data$k_percent_cur)),
         list(label = "BB%", value = format_percentage(player_data$bb_percent_cur)),
         list(label = "BABIP", value = babip_val),
@@ -977,8 +977,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
         cat("✅ DEBUG: Generating pitcher stats\n")
         # Clean current stats display
         stats <- list(
-          list(label = "ERA", value = format_stat_value(player_data$era_cur)),
-          list(label = "xERA", value = format_stat_value(player_data$xera_cur)),
+          list(label = "ERA", value = format_era(player_data$era_cur)),
+          list(label = "xERA", value = format_era(player_data$xera_cur)),
           list(label = "K%", value = format_percentage(player_data$k_percent_cur)),
           list(label = "BB%", value = format_percentage(player_data$bb_percent_cur)),
           list(label = "BABIP", value = format_stat_value(player_data$babip_cur)),


### PR DESCRIPTION
## Summary
- Format sub-one numeric stats without leading zero and always show three decimal places
- Use the unified formatter in server logic for AVG, OBP, SLG, and wOBA displays

## Testing
- `R -q -e "source('app/R/analysis.R'); print(format_stat_value(0.123));"` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b222c5a214832b8a4c3412f20c12fd