### PR TITLE
Move player selector into step 1 flow

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -122,7 +122,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
       div(
         class = "step-header",
         div(class = if (player_selected) "step-number" else "step-number inactive", "1"),
-        h3(class = if (player_selected) "step-title" else "step-title inactive", "Player Selected"),
+        h3(class = if (player_selected) "step-title" else "step-title inactive", "Select a Player"),
         # AI Analysis status badge in header
         if (player_selected) {
           if (ai_loading) {
@@ -133,12 +133,27 @@ generate_player_stat_line <- function(player_id, baseball_data) {
             )
           } else if (!is.null(ai_result)) {
             span(
-              class = "badge bg-success ms-3", 
+              class = "badge bg-success ms-3",
               tags$i(class = "fas fa-check-circle me-1"),
               "Analysis Ready"
             )
           }
         }
+      ),
+      div(
+        class = "search-input-container",
+        selectInput(
+          inputId = "player_selection",
+          label = "Search for a player:",
+          choices = NULL,
+          width = "100%"
+        )
+      ),
+      div(
+        class = "quick-filters",
+        span(class = "filter-chip active", "All Players"),
+        span(class = "filter-chip", "Hitters"),
+        span(class = "filter-chip", "Pitchers")
       ),
       if (player_selected && !is.null(player_info)) {
         tagList(

--- a/app/ui.R
+++ b/app/ui.R
@@ -585,26 +585,6 @@ ui <- page_navbar(
       )
     ),
 
-    # Player Search Section
-    div(
-      class = "search-card",
-      div(
-        class = "search-input-container",
-        selectInput(
-          inputId = "player_selection",
-          label = "Search for a player:",
-          choices = NULL,
-          width = "100%"
-        )
-      ),
-      div(
-        class = "quick-filters",
-        span(class = "filter-chip active", "All Players"),
-        span(class = "filter-chip", "Hitters"),
-        span(class = "filter-chip", "Pitchers")
-      )
-    ),
-
     # Step 1: Player Selection
     uiOutput("step_1_player_selection"),
 


### PR DESCRIPTION
## Summary
- Remove standalone player search card from the UI layout.
- Embed player selector and quick filters at the start of Step 1 with header "Select a Player".
- Show stat line and quick insight only after a player is chosen, preserving existing selection logic.

## Testing
- ❌ `Rscript run_tests.R` *(Rscript not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68b2fe8af66c832b864f6e0a2d091889