### PR TITLE
Reduce hero section spacing

### DIFF
--- a/app/ui.R
+++ b/app/ui.R
@@ -12,7 +12,7 @@ ui <- page_navbar(
       .hero-section {
         text-align: center;
         color: white;
-        margin: 2rem 0 3rem 0;
+        margin: 1rem 0 1rem 0;
         padding: 0 1rem;
       }
 


### PR DESCRIPTION
## Summary
- decrease vertical margin around homepage hero section to keep content closer to top

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: 403  Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f89ab6c8832b8ae93cf1c8724701