### PR TITLE
Enable searchable player selection with selectize

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -264,7 +264,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
     updateSelectizeInput(
       session,
       "player_selection",
-      choices = player_choices(),
+      choices = isolate(player_choices()),
       selected = isolate(input$player_selection %||% ""),
       server = TRUE
     )

--- a/app/server.R
+++ b/app/server.R
@@ -259,7 +259,19 @@ generate_player_stat_line <- function(player_id, baseball_data) {
     }
   })
 
-  observe({
+  # Ensure the player select loads options after the input is rendered
+  session$onFlushed(function() {
+    updateSelectizeInput(
+      session,
+      "player_selection",
+      choices = player_choices(),
+      selected = isolate(input$player_selection %||% ""),
+      server = TRUE
+    )
+  }, once = TRUE)
+
+  # Refresh available players when the filter changes
+  observeEvent(input$player_filter, {
     updateSelectizeInput(
       session,
       "player_selection",


### PR DESCRIPTION
## Summary
- Replace player select input with `selectizeInput` for built-in search and placeholder guidance
- Populate player list via `updateSelectizeInput(..., server = TRUE)` for efficient loading

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y r-base` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b31ba5aee8832bb69728e9adbb42be