### PR TITLE
Ensure async AI analysis updates run in reactive domain

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -145,7 +145,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
             } else {
               setNames(lookup$PlayerId, lookup$display_name)
             }
-            c("Select a player..." = "", player_choices)
+            invisible(c("Select a player..." = "", player_choices))
           },
           selected = isolate(input$player_selection),
           width = "100%"

--- a/app/server.R
+++ b/app/server.R
@@ -841,27 +841,31 @@ generate_player_stat_line <- function(player_id, baseball_data) {
             tryCatch(
               {
                 cat("🤖 Generating AI analysis...\n")
-                
+
                 analysis_result <- analyze_player_performance(
                   player_selection,
                   analysis_mode,
                   baseball_data
                 )
-                
-                # Update when complete
-                values$ai_analysis_result <- analysis_result
-                values$ai_analysis_loading <- FALSE
-                
+
+                # Update when complete within session's reactive domain
+                shiny::withReactiveDomain(session, {
+                  values$ai_analysis_result <- analysis_result
+                  values$ai_analysis_loading <- FALSE
+                })
+
                 cat("✅ ASYNC: AI analysis complete for:", analysis_key, "\n")
               },
               error = function(e) {
                 cat("❌ ASYNC: Error in AI analysis:", e$message, "\n")
-                values$ai_analysis_loading <- FALSE
-                values$ai_analysis_result <- HTML(paste0(
-                  "<div class='alert alert-danger'>",
-                  "Error generating analysis: ", e$message,
-                  "</div>"
-                ))
+                shiny::withReactiveDomain(session, {
+                  values$ai_analysis_loading <- FALSE
+                  values$ai_analysis_result <- HTML(paste0(
+                    "<div class='alert alert-danger'>",
+                    "Error generating analysis: ", e$message,
+                    "</div>"
+                  ))
+                })
               }
             )
           }, delay = 0.1)


### PR DESCRIPTION
## Summary
- Ensure AI analysis completions and failures update reactive values within the session's domain so the UI can refresh properly

## Testing
- `Rscript run_tests.R` *(fails: command not found: Rscript)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dc008218832baddbe0bdf26a6be5