### PR TITLE
Streamlined player search and default vibe

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -40,7 +40,7 @@ server <- function(input, output, session) {
     stat_line_data = NULL  # current stat line
   )
   
-  # Populate player picker on startup
+  # Populate player selector on startup
   observe({
     lookup <- baseball_data$lookup
     if ("compound_id" %in% colnames(lookup)) {
@@ -50,37 +50,10 @@ server <- function(input, output, session) {
       ids <- lookup$PlayerId
       names <- lookup$display_name
     }
-    updatePickerInput(session, "player_selection",
-                      choices = setNames(ids, names),
-                      selected = NULL)
-  })
-
-  observeEvent(input$player_filter, {
-    lookup <- baseball_data$lookup
-    if (!is.null(input$player_filter)) {
-      if (input$player_filter == "Hitters") {
-        lookup <- lookup %>% filter(player_type == "hitter")
-      } else if (input$player_filter == "Pitchers") {
-        lookup <- lookup %>% filter(player_type == "pitcher")
-      }
-    }
-    if ("compound_id" %in% colnames(lookup)) {
-      ids <- lookup$compound_id
-      names <- lookup$display_name
-    } else {
-      ids <- lookup$PlayerId
-      names <- lookup$display_name
-    }
-    selected <- isolate({
-      if (!is.null(input$player_selection) && input$player_selection %in% ids) {
-        input$player_selection
-      } else {
-        NULL
-      }
-    })
-    updatePickerInput(session, "player_selection",
-                      choices = setNames(ids, names),
-                      selected = selected)
+    updateSelectizeInput(session, "player_selection",
+                         choices = setNames(ids, names),
+                         selected = NULL,
+                         server = TRUE)
   })
 
   # ============================================================================
@@ -685,6 +658,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
                  
                  
                  if (!is.null(input$player_selection) && nzchar(input$player_selection)) {
+                   # Default to standard vibe whenever a new player is chosen
+                   values$analysis_mode <- "default"
                    player_info <- get_player_info(input$player_selection, baseball_data)
                    
                    if (!is.null(player_info)) {

--- a/app/ui.R
+++ b/app/ui.R
@@ -57,38 +57,12 @@ ui <- page_navbar(
         margin-bottom: 2rem;
       }
 
-      .search-input-container .bootstrap-select > .dropdown-toggle {
+      .search-input-container .selectize-input {
         border: 2px solid rgba(46, 134, 171, 0.2);
         border-radius: 15px;
         padding: 1rem 1.5rem;
         font-size: 1.1rem;
         background: rgba(255, 255, 255, 0.9);
-      }
-
-      .quick-filters {
-        display: flex;
-        gap: 0.5rem;
-        flex-wrap: wrap;
-        margin-top: 1rem;
-        margin-bottom: 1rem;
-      }
-
-      .filter-chip {
-        background: rgba(46, 134, 171, 0.1);
-        border: 1px solid rgba(46, 134, 171, 0.3);
-        border-radius: 25px;
-        padding: 0.5rem 1rem;
-        font-size: 0.9rem;
-        color: #2E86AB;
-        cursor: pointer;
-        transition: all 0.3s ease;
-        text-decoration: none;
-      }
-
-      .filter-chip:hover, .filter-chip.active {
-        background: #2E86AB;
-        color: white;
-        transform: translateY(-1px);
       }
 
       .step-card {
@@ -506,16 +480,6 @@ ui <- page_navbar(
       console.log('🎨 Analysis mode changed to:', mode);
     });
 
-    // Filter chip interaction
-    $(document).on('click', '.filter-chip', function() {
-      $('.filter-chip').removeClass('active');
-      $(this).addClass('active');
-
-      var filterType = $(this).text().trim();
-      console.log('🏷️ Filter changed to:', filterType);
-      Shiny.setInputValue('player_filter', filterType, {priority: 'event'});
-    });
-
     // Smart scroll to analysis - only when analysis is newly generated
     var observer = new MutationObserver(function(mutations) {
       mutations.forEach(function(mutation) {
@@ -597,22 +561,18 @@ ui <- page_navbar(
       ),
       div(
         class = "search-input-container",
-        pickerInput(
+        selectizeInput(
           inputId = "player_selection",
           label = NULL,
           choices = NULL,
-          options = pickerOptions(
-            liveSearch = TRUE,
-            title = "Select a player..."
+          options = list(
+            placeholder = "Type a player name",
+            openOnFocus = FALSE,
+            closeAfterSelect = TRUE
           ),
-          width = "100%"
+          width = "100%",
+          server = TRUE
         )
-      ),
-      div(
-        class = "quick-filters",
-        span(class = "filter-chip active", "All Players"),
-        span(class = "filter-chip", "Hitters"),
-        span(class = "filter-chip", "Pitchers")
       ),
       uiOutput("player_preview")
     ),


### PR DESCRIPTION
## Summary
- Replace picker-based player selector with a simple type-ahead `selectizeInput`
- Remove hitter/pitcher filter chips and related logic
- Reset analysis mode to default whenever a new player is chosen, triggering automatic analysis

## Testing
- ⚠️ `R -q -e "source('run_tests.R')"` *(R not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68b607861f0c832b8c21d7de9b66fd1e