### PR TITLE
Rename console logger to avoid overriding DB logger

### DIFF
--- a/app/R/setup.R
+++ b/app/R/setup.R
@@ -133,8 +133,8 @@ if (exists("init_analytics_db")) {
   init_analytics_db()
 }
 
-# Tidyverse-style analysis logger
-log_analysis <- function(player_name, analysis_mode, ...) {
+# Tidyverse-style console logger (no session)
+log_analysis_console <- function(player_name, analysis_mode, ...) {
   timestamp <- format(Sys.time(), "%Y-%m-%d %H:%M:%S")
 
   message_parts <- c(


### PR DESCRIPTION
## Summary
- Rename tidyverse-style logger to `log_analysis_console`
- Preserve session-aware `log_analysis` for database logging
- Ensure no mismatched logger calls

## Testing
- `Rscript run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7048fee30832bafe92cf21403f4b9