### PR TITLE
Disable keepalive and reconnect loop

### DIFF
--- a/app/R/setup.R
+++ b/app/R/setup.R
@@ -23,12 +23,12 @@ if (Sys.getenv("RENDER") == "true") {
   cat("✓ Development mode\n")
 }
 
-# Keep-alive options
-options(
-  shiny.disconnected.timeout = 300000, # 5 minutes in milliseconds
-  shiny.autoreload.interval = 500, # Check every 500ms
-  shiny.websocket.ping.interval = 25000 # 25 seconds
-)
+# Keep-alive options temporarily disabled
+# options(
+#   shiny.disconnected.timeout = 300000, # 5 minutes in milliseconds
+#   shiny.autoreload.interval = 500, # Check every 500ms
+#   shiny.websocket.ping.interval = 25000 # 25 seconds
+# )
 
 cat("=== CHECKING ENVIRONMENT ===\n")
 cat("RENDER env var:", Sys.getenv("RENDER"), "\n")

--- a/app/server.R
+++ b/app/server.R
@@ -4,21 +4,7 @@ server <- function(input, output, session) {
   # Generate user ID on session start
   user_id <- generate_user_id(session)
   
-  # Keep-alive ping handler
-  observeEvent(input$keepalive_ping,
-               {
-                 if (!is.null(input$keepalive_ping)) {
-                   timestamp <- as.POSIXct(input$keepalive_ping / 1000, origin = "1970-01-01")
-                   cat(
-                     "💓 Keep-alive ping received at:", format(timestamp, "%H:%M:%S"),
-                     "- User:", substr(user_id, 1, 8), "...\n"
-                   )
-                   session$userData$last_keepalive <- Sys.time()
-                 }
-               },
-               ignoreInit = TRUE,
-               ignoreNULL = TRUE
-  )
+  # Keep-alive ping handler temporarily disabled
   
   # Session ended handler
   session$onSessionEnded(function() {

--- a/app/ui.R
+++ b/app/ui.R
@@ -385,71 +385,7 @@ ui <- page_navbar(
     ")),
     add_busy_bar(color = "#2E86AB", height = "25px"),
 
-    # Keep your existing JavaScript for keep-alive
-    tags$script(HTML("
-      $(document).ready(function() {
-        console.log('🔄 Keep-alive system initialized');
-        var keepAliveInterval = 120000;
-        var keepAliveTimer;
-        var lastActivity = Date.now();
-        var isVisible = true;
-
-        function sendKeepAlivePing() {
-          if (!isVisible) {
-            console.log('⏸️ Tab not visible, skipping keep-alive ping');
-            return;
-          }
-          console.log('💓 Sending keep-alive ping');
-          Shiny.setInputValue('keepalive_ping', Date.now(), {priority: 'event'});
-        }
-
-        function updateActivity() {
-          lastActivity = Date.now();
-          console.log('👤 User activity detected');
-          clearInterval(keepAliveTimer);
-          startKeepAlive();
-        }
-
-        function startKeepAlive() {
-          keepAliveTimer = setInterval(function() {
-            var timeSinceActivity = Date.now() - lastActivity;
-            if (timeSinceActivity < 600000) {
-              sendKeepAlivePing();
-            } else {
-              console.log('💤 No recent activity, pausing keep-alive');
-            }
-          }, keepAliveInterval);
-        }
-
-        document.addEventListener('visibilitychange', function() {
-          isVisible = !document.hidden;
-          if (isVisible) {
-            console.log('👁️ Tab visible, resuming keep-alive');
-            updateActivity();
-          } else {
-            console.log('🙈 Tab hidden, pausing keep-alive');
-          }
-        });
-
-        ['mousedown', 'mousemove', 'keypress', 'scroll', 'touchstart', 'click'].forEach(function(event) {
-          document.addEventListener(event, updateActivity, true);
-        });
-
-        setInterval(function() {
-          if (Shiny && Shiny.shinyapp && Shiny.shinyapp.isConnected()) {
-            console.log('💚 Shiny connection healthy');
-          } else {
-            console.log('💔 Shiny connection lost - attempting reconnect');
-            if (Shiny && Shiny.shinyapp && Shiny.shinyapp.reconnect) {
-              Shiny.shinyapp.reconnect();
-            }
-          }
-        }, 30000);
-
-        startKeepAlive();
-        console.log('✅ Keep-alive system active');
-      });
-    ")), 
+      # Keep-alive and reconnect loop temporarily disabled
     tags$script(HTML(" 
   $(document).ready(function() {
     var lastAnalysisTime = 0;


### PR DESCRIPTION
## Summary
- Temporarily disable custom keep-alive and auto-reconnect scripts.
- Remove server-side keepalive observer.
- Comment out custom websocket timeout/ping options.

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed; unable to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f276c62c832b889af11afb6182e6