### PR TITLE
feat: update in-app instructions

### DIFF
--- a/app/ui.R
+++ b/app/ui.R
@@ -478,11 +478,13 @@ ui <- page_navbar(
       role = "alert",
       HTML(
         "<div class='instruction-steps'>
-            <span>1. 🧢 Pick a player</span>
+            <span>🧢 Pick a player</span>
             <span>&rarr;</span>
-            <span>2. 🎧 Choose a vibe</span>
+            <span>🎧 Choose a vibe</span>
             <span>&rarr;</span>
-            <span>3. 📊 Read the analysis</span>
+            <span>📊 Read the analysis</span>
+            <span>&rarr;</span>
+            <span>🤝 Share with friends</span>
         </div>"
       ),
       tags$button(


### PR DESCRIPTION
## Summary
- remove numbering from in-app quick instructions and add "Share with friends"
- revert README to original numbered usage instructions

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `apt-get install -y r-base` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68b887465a4c832ba18f5bb15486741f