### PR TITLE
Add visibility-aware heartbeat and auto-reload

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -1,10 +1,13 @@
 # Server
 # Complete Server Logic with Internal UI Functions and Trends in Step 1
 server <- function(input, output, session) {
+  session$allowReconnect(TRUE)
+
   # Generate user ID on session start
   user_id <- generate_user_id(session)
 
-  # Keep-alive ping handler temporarily disabled
+  # Visibility-aware keep-alive ping from JS
+  observeEvent(input$heartbeat, {}, ignoreNULL = TRUE)
 
   # Session ended handler
   session$onSessionEnded(function() {

--- a/app/ui.R
+++ b/app/ui.R
@@ -6,8 +6,35 @@ ui <- page_navbar(
   header = tagList(
     tags$meta(name = "viewport", content = "width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no, viewport-fit=cover, shrink-to-fit=no"),
     tags$style(ui_styles), # Keep your existing styles
+    tags$script(HTML("
+      var heartbeatInterval;
+      function startHeartbeat() {
+        heartbeatInterval = setInterval(function() {
+          Shiny.setInputValue('heartbeat', Date.now(), {priority: 'event'});
+        }, 15000);
+      }
+      function stopHeartbeat() {
+        if (heartbeatInterval) {
+          clearInterval(heartbeatInterval);
+          heartbeatInterval = null;
+        }
+      }
+      document.addEventListener('visibilitychange', function() {
+        if (document.visibilityState === 'visible') {
+          startHeartbeat();
+        } else {
+          stopHeartbeat();
+        }
+      });
+      if (document.visibilityState === 'visible') {
+        startHeartbeat();
+      }
+      $(document).on('shiny:disconnected', function() {
+        setTimeout(function(){ location.reload(); }, 3000);
+      });
+    ")),    
     # Add new styles for the progressive flow
-    tags$style(HTML("
+    tags$style(HTML("       
       /* Progressive Flow Specific Styles */
       .hero-section {
         text-align: center;


### PR DESCRIPTION
## Summary
- allow Shiny sessions to reconnect and handle heartbeat input
- add visibility-aware heartbeat JS with auto-reload on disconnect

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: repository 403 errors when attempting to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68b75b7b6c6c832bbb4fd108a39cecbc