### PR TITLE
Use dropdown for mobile vibe selector

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -263,35 +263,20 @@ generate_player_stat_line <- function(player_id, baseball_data) {
             )
           ),
           
-          # Mobile Option A: Compact vertical stack
+          # Mobile: Dropdown selector
           div(
-            class = "vibe-selector-mobile d-md-none",
-            map(vibe_options, ~ {
-              option_class <- if (.x$mode == current_mode) "vibe-option-mobile selected" else "vibe-option-mobile"
-              div(
-                class = option_class,
-                `data-mode` = .x$mode,
-                onclick = str_glue("Shiny.setInputValue('analysis_mode', '{.x$mode}', {{priority: 'event'}});"),
-                span(class = "vibe-option-icon", .x$icon),
-                div(
-                  class = "vibe-option-text",
-                  div(class = "vibe-option-name", .x$name),
-                  div(class = "vibe-option-desc", 
-                      case_when(
-                        .x$mode == "default" ~ "Clear, data-driven analysis",
-                        .x$mode == "analytics_dork" ~ "Modern stats, dismissive vibes",
-                        .x$mode == "old_coot" ~ "Grumpy old-school wisdom",
-                        .x$mode == "gen_z" ~ "Modern slang and trends",
-                        .x$mode == "seventies" ~ "Retro baseball perspective",
-                        .x$mode == "sensationalist" ~ "Dramatic sports journalism",
-                        .x$mode == "shakespeare" ~ "Iambic pentameter analysis",
-                        .x$mode == "rose_colored_glasses" ~ "Always positive",
-                        TRUE ~ ""
-                      )
-                  )
-                )
-              )
-            })
+            class = "vibe-dropdown-mobile d-md-none",
+            selectInput(
+              "analysis_mode",
+              label = NULL,
+              choices = setNames(
+                purrr::map_chr(vibe_options, "mode"),
+                purrr::map_chr(vibe_options, ~ paste0(.x$icon, " ", .x$name))
+              ),
+              selected = current_mode,
+              selectize = FALSE,
+              width = "100%"
+            )
           )
           
       
@@ -749,7 +734,8 @@ generate_player_stat_line <- function(player_id, baseball_data) {
                  if (!is.null(input$analysis_mode)) {
                    cat("🎨 Analysis mode changed to:", input$analysis_mode, "\n")
                    values$analysis_mode <- input$analysis_mode
-                   
+                   updateSelectInput(session, "analysis_mode", selected = input$analysis_mode)
+
                    # Clear previous AI analysis when mode changes
                    values$ai_analysis_result <- NULL
                    values$ai_analysis_loading <- FALSE

--- a/app/ui.R
+++ b/app/ui.R
@@ -263,80 +263,13 @@ ui <- page_navbar(
   line-height: 1.2;
 }
 
-/* Mobile: Compact vertical stack - Option A */
-.vibe-selector-mobile {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+/* Mobile: Dropdown selector */
+.vibe-dropdown-mobile {
   margin-top: 1rem;
 }
 
-.vibe-option-mobile {
-  background: rgba(255, 255, 255, 0.9);
-  border: 2px solid rgba(46, 134, 171, 0.2);
-  border-radius: 8px;
-  padding: 0.75rem 1rem;
-  cursor: pointer;
-  transition: all 0.3s ease;
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-  position: relative;
-}
-
-.vibe-option-mobile:hover {
-  border-color: #2E86AB;
-  background: rgba(46, 134, 171, 0.1);
-}
-
-.vibe-option-mobile.selected {
-  border-color: #2E86AB;
-  background: rgba(46, 134, 171, 0.15);
-  box-shadow: 0 2px 8px rgba(46, 134, 171, 0.3);
-}
-
-.vibe-option-mobile.selected::after {
-  content: '✓';
-  position: absolute;
-  top: 50%;
-  right: 1rem;
-  transform: translateY(-50%);
-  background: #2E86AB;
-  color: white;
-  width: 20px;
-  height: 20px;
-  border-radius: 50%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 0.75rem;
-  font-weight: bold;
-}
-
-.vibe-option-icon {
-  font-size: 1.5rem;
-  flex-shrink: 0;
-}
-
-.vibe-option-text {
-  display: flex;
-  flex-direction: column;
-  flex-grow: 1;
-}
-
-.vibe-option-name {
-  font-weight: 600;
-  color: #2E86AB;
-  font-size: 0.9rem;
-  margin: 0;
-  line-height: 1.2;
-}
-
-.vibe-option-desc {
-  font-size: 0.75rem;
-  color: #6c757d;
-  margin: 0;
-  line-height: 1.2;
+.vibe-dropdown-mobile select {
+  font-size: 1rem;
 }
 
       .insight-summary {


### PR DESCRIPTION
## Summary
- Replace tall mobile vibe card with a compact emoji dropdown selector.
- Keep dropdown selection in sync with server logic.
- Add styling for new mobile dropdown.

## Testing
- `Rscript run_tests.R` *(fails: command not found)*
- `apt-get update` *(fails: repositories not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a1a55dc832b9f1fb1663e5716c0