### PR TITLE
Remove redundant player card empty state

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -196,12 +196,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
         }
       )
     } else {
-      div(
-        class = "empty-state",
-        icon("search", class = "empty-icon"),
-        h4(class = "empty-title", "Select a player above"),
-        p(class = "empty-subtitle", "Choose from over 500 MLB players to get started")
-      )
+      NULL
     }
   }
   


### PR DESCRIPTION
## Summary
- Remove duplicate "Select a player above" empty state from initial player card

## Testing
- `Rscript run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5a5402f0832bbaf200f9a3fd231c