### PR TITLE
Ensure later package is loaded for AI analysis

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN R -e "install.packages(c('shiny', 'dplyr', 'readr', 'purrr', 'stringr'), rep
 # Install UI packages (cached layer)
 RUN R -e "install.packages(c('httr', 'jsonlite', 'bslib', 'ggplot2', 'htmltools'), repos='https://cran.rstudio.com/')"
 
-# Install utility packages (cached layer)  
-RUN R -e "install.packages(c('commonmark', 'shinybusy', 'digest', 'shinyWidgets'), repos='https://cran.rstudio.com/')"
+# Install utility packages (cached layer)
+RUN R -e "install.packages(c('commonmark', 'shinybusy', 'digest', 'shinyWidgets', 'later'), repos='https://cran.rstudio.com/')"
 
 # Install database packages (new layer)
 RUN R -e "install.packages(c('DBI', 'RSQLite', 'RPostgreSQL', 'uuid'), repos='https://cran.rstudio.com/')"

--- a/app/R/setup.R
+++ b/app/R/setup.R
@@ -62,7 +62,7 @@ tryCatch(
 # Load other essential packages
 for (pkg in c(
   "readr", "purrr", "stringr", "httr", "jsonlite",
-  "bslib", "commonmark", "shinybusy", "shinyWidgets", "ggplot2", "htmltools", "digest"
+  "bslib", "commonmark", "shinybusy", "shinyWidgets", "ggplot2", "htmltools", "digest", "later"
 )) {
   tryCatch(
     {
@@ -107,6 +107,7 @@ library(shinyWidgets) # Enhanced select inputs
 library(ggplot2) # Data visualization
 library(htmltools) # HTML utilities (HTML, htmlEscape)
 library(digest) # CACHE: Added for generating cache keys
+library(later) # Asynchronous task scheduling
 library(DBI) # Database interface
 library(RSQLite) # SQLite (for development)
 library(digest) # For hashing (if using PostgreSQL later)

--- a/run_tests.R
+++ b/run_tests.R
@@ -14,6 +14,7 @@ suppressPackageStartupMessages({
   library(digest)
   library(tibble)
   library(rlang)
+  library(later)
 })
 
 # Minimal application environment -------------------------------------------


### PR DESCRIPTION
## Summary
- include the `later` package in setup to ensure async AI analysis works after deployment
- load `later` during tests for consistent dependencies
- install the `later` package in the Docker image so deployed containers have the dependency

## Testing
- `Rscript run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc5fbe6590832bb4f9b8fc58f15a69