### PR TITLE
Enable shareable analysis URLs while preserving admin no-log mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ GitHub Actions pulls fresh stats every morning at 6 AM EST.
 1. Select a player from the dropdown
 2. Pick your preferred vibe
 3. Read an easy-to-digest breakdown with trends and context
+4. Share the analysis by copying the URL – it updates with the current player and vibe and runs automatically when opened
 
 ### Reading the output
 - Green trends indicate positive movement

--- a/app/admin.R
+++ b/app/admin.R
@@ -2,7 +2,8 @@
 
 # Check if session has admin privileges
 is_admin <- function(session) {
-  query <- parseQueryString(session$clientData$url_search)
+  # Access the URL query string without triggering reactivity
+  query <- parseQueryString(isolate(session$clientData$url_search))
   if (!is.null(query$admin) && query$admin == Sys.getenv("ADMIN_PASSWORD", "")) {
     session$userData$admin_mode <- TRUE
     return(TRUE)


### PR DESCRIPTION
## Summary
- Keep existing password-based admin check without introducing a `nolog` URL parameter
- Continue updating browser URL with selected player and vibe on each analysis run for shareable links
- Generate share links without exposing admin-specific flags

## Testing
- `apt-get update` *(fails: repository is not signed)*
- `apt-get install -y r-base` *(fails: unable to locate package r-base)*
- `Rscript run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb24022ec832bb3d73ef5c3d50d26