### PR TITLE
Preserve admin param in URLs

### DIFF
--- a/app/server.R
+++ b/app/server.R
@@ -838,6 +838,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
     params <- list()
     if (!is.null(player_id) && nzchar(player_id)) params$player <- player_id
     if (!is.null(mode) && nzchar(mode)) params$vibe <- mode
+    if (is_admin(session)) params$admin <- Sys.getenv("ADMIN_PASSWORD", "")
     query <- paste(names(params), params, sep = "=", collapse = "&")
     updateQueryString(paste0("?", query), mode = "replace", session = session)
   }, ignoreNULL = TRUE)


### PR DESCRIPTION
## Summary
- Preserve admin password in query string so admin sessions remain active and analytics logging is bypassed

## Testing
- ⚠️ `Rscript run_tests.R` *(command not found)*
- ⚠️ `apt-get update` *(403 on Ubuntu repositories; unable to install R)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd1775528832b914055cf8232357d