### PR TITLE
Log session starts for funnel analysis

### DIFF
--- a/app/R/setup.R
+++ b/app/R/setup.R
@@ -122,7 +122,9 @@ tryCatch(
   error = function(e) {
     # Create dummy functions if analytics fails
     is_admin <- function(session) FALSE
-    log_if_not_admin <- function(session, log_function, ...) {}
+    log_analysis_if_not_admin <- function(session, player_name, analysis_mode) {}
+    log_share_if_not_admin <- function(session, player_name, analysis_mode, event_type) {}
+    log_session_if_not_admin <- function(session) {}
     init_analytics_db <- function() {}
     generate_user_id <- function(session) "dummy"
     track_user <- function(...) {}

--- a/app/admin.R
+++ b/app/admin.R
@@ -12,7 +12,7 @@ is_admin <- function(session) {
 }
 
 # Log analysis unless user is admin
-log_if_not_admin <- function(session, player_name, analysis_mode) {
+log_analysis_if_not_admin <- function(session, player_name, analysis_mode) {
   if (!is_admin(session)) {
     log_analysis(session, player_name, analysis_mode)
   } else {
@@ -27,3 +27,12 @@ log_share_if_not_admin <- function(session, player_name, analysis_mode, event_ty
     cat("🔧 Admin share - not logged\n")
   }
 }
+
+log_session_if_not_admin <- function(session) {
+  if (!is_admin(session)) {
+    log_session_start(session)
+  } else {
+    cat("🔧 Admin session - not logged\n")
+  }
+}
+

--- a/app/server.R
+++ b/app/server.R
@@ -5,6 +5,7 @@ server <- function(input, output, session) {
 
   # Generate user ID on session start
   user_id <- generate_user_id(session)
+  log_session_if_not_admin(session)
 
   # Visibility-aware keep-alive ping from JS
   observeEvent(input$heartbeat, {}, ignoreNULL = TRUE)
@@ -92,7 +93,7 @@ server <- function(input, output, session) {
 
     player_names <- purrr::map_chr(players, function(p) p$info$name)
     analysis_mode <- values$analysis_mode
-    log_if_not_admin(session, paste(player_names, collapse = " vs "), analysis_mode)
+    log_analysis_if_not_admin(session, paste(player_names, collapse = " vs "), analysis_mode)
 
     rec_id <- recommend_best_player(ids, baseball_data)
     rec_name <- if (!is.null(rec_id)) get_player_info(rec_id, baseball_data)$name else NULL
@@ -802,7 +803,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
 
         analysis_key <- paste(player_info$name, current_mode, sep = "_")
         if (analysis_key != values$last_logged_key) {
-          log_if_not_admin(session, player_info$name, current_mode)
+          log_analysis_if_not_admin(session, player_info$name, current_mode)
           if (isTRUE(values$pending_share_run)) {
             log_share_if_not_admin(session, player_info$name, current_mode, "shared_run")
             values$pending_share_run <- FALSE
@@ -833,7 +834,7 @@ generate_player_stat_line <- function(player_id, baseball_data) {
     if (!is.null(values$selected_player_info)) {
       analysis_key <- paste(values$selected_player_info$name, mode, sep = "_")
       if (analysis_key != values$last_logged_key) {
-        log_if_not_admin(session, values$selected_player_info$name, mode)
+        log_analysis_if_not_admin(session, values$selected_player_info$name, mode)
         if (isTRUE(values$pending_share_run)) {
           log_share_if_not_admin(session, values$selected_player_info$name, mode, "shared_run")
           values$pending_share_run <- FALSE
@@ -1009,3 +1010,4 @@ generate_player_stat_line <- function(player_id, baseball_data) {
   outputOptions(output, "step_2_analysis_style", suspendWhenHidden = FALSE)
   outputOptions(output, "step_3_analysis_results", suspendWhenHidden = FALSE)
 }
+


### PR DESCRIPTION
## Summary
- Record session start events in analytics database
- Skip logging for admin users with explicit analysis wrapper
- Track visits by logging sessions on server start

## Testing
- `Rscript run_tests.R` *(fails: command not found: Rscript)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ec5b730832ba4a6cd87ae5d882f