### PR TITLE
Unify single and multi-player analysis navigation

### DIFF
--- a/app/R/compare.R
+++ b/app/R/compare.R
@@ -100,6 +100,6 @@ analyze_player_comparison <- function(player_ids, baseball_data, analysis_mode) 
   if (is.null(prompt)) {
     return(htmltools::HTML("<div class='alert alert-warning'>No players to analyze.</div>"))
   }
-  call_openai_api(prompt, analysis_mode)
+  call_openai_api(prompt, analysis_mode, context = "comparison")
 }
 

--- a/app/server.R
+++ b/app/server.R
@@ -24,7 +24,8 @@ server <- function(input, output, session) {
   initial_vibe <- initial_query$vibe
   initial_view <- initial_query$view %||% if (!is.null(initial_query$players)) "compare" else "single"
   initial_compare_players <- if (!is.null(initial_query$players)) {
-    trimws(strsplit(initial_query$players, ",")[[1]])
+    players <- trimws(strsplit(initial_query$players, ",")[[1]])
+    players[nzchar(players)]
   } else {
     NULL
   }
@@ -59,6 +60,7 @@ server <- function(input, output, session) {
     stat_line_data = NULL,  # current stat line
     pending_share_run = !is.null(initial_player),
     pending_compare_run = !is.null(initial_compare_players) && length(initial_compare_players) > 0,
+    pending_compare_expected = if (!is.null(initial_compare_players)) length(initial_compare_players) else 0,
     compare_results = NULL,
     compare_ai_result = NULL,
     compare_ai_loading = FALSE,
@@ -217,8 +219,10 @@ server <- function(input, output, session) {
     if (isTRUE(values$pending_compare_run)) {
       players <- c(input$compare_player1, input$compare_player2, input$compare_player3)
       players <- players[players != ""]
-      if (length(players) > 0) {
+      expected <- values$pending_compare_expected %||% 0
+      if (length(players) >= max(1, expected)) {
         values$pending_compare_run <- FALSE
+        values$pending_compare_expected <- 0
         run_compare_analysis()
       }
     }

--- a/app/server.R
+++ b/app/server.R
@@ -1121,6 +1121,9 @@ generate_player_stat_line <- function(player_id, baseball_data) {
   # Share analysis on X (Twitter)
   observeEvent(input$share_x, {
     req(values$selected_player_info)
+    req(input$player_selection)
+
+    mode <- values$analysis_mode %||% "default"
     base_url <- paste0(
       session$clientData$url_protocol, "//",
       session$clientData$url_hostname,

--- a/app/server.R
+++ b/app/server.R
@@ -178,7 +178,8 @@ server <- function(input, output, session) {
       )
 
       shiny::withReactiveDomain(session, {
-        if (!identical(values$current_compare_key, compare_key_local)) {
+        current_key <- shiny::isolate(values$current_compare_key)
+        if (!identical(current_key, compare_key_local)) {
           cat("⏭️ Ignoring stale comparison analysis for:", compare_key_local, "\n")
           return()
         }

--- a/app/server.R
+++ b/app/server.R
@@ -74,7 +74,7 @@ server <- function(input, output, session) {
     )
   })
 
-  observe({
+  observeEvent(TRUE, {
     updateRadioButtons(
       session,
       "analysis_view",
@@ -82,7 +82,7 @@ server <- function(input, output, session) {
     )
   }, once = TRUE)
 
-  observe({
+  observeEvent(TRUE, {
     default_type <- values$initial_compare_type %||% "hitter"
     updateRadioButtons(session, "compare_type", selected = default_type)
   }, once = TRUE)

--- a/app/ui.R
+++ b/app/ui.R
@@ -488,7 +488,6 @@ ui <- page_navbar(
               maxOptions = 5,
               onDropdownOpen = I("function(dropdown) { if (!this.lastQuery.length) { this.close(); } }")
             ),
-            server = TRUE,
             width = "100%"
           )
         ),
@@ -511,7 +510,6 @@ ui <- page_navbar(
                 "Player 1",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
-                server = TRUE,
                 width = "100%"
               )
             ),
@@ -522,7 +520,6 @@ ui <- page_navbar(
                 "Player 2",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
-                server = TRUE,
                 width = "100%"
               )
             ),
@@ -533,7 +530,6 @@ ui <- page_navbar(
                 "Player 3",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
-                server = TRUE,
                 width = "100%"
               )
             )

--- a/app/ui.R
+++ b/app/ui.R
@@ -461,25 +461,81 @@ ui <- page_navbar(
       div(
         class = "step-header",
         div(class = "step-number", "1"),
-        h3(class = "step-title", "Select a Player")
+        h3(class = "step-title", "Choose Players")
       ),
       div(
-        class = "search-input-container",
-        selectizeInput(
-          inputId = "player_selection",
+        class = "mb-3",
+        radioButtons(
+          "analysis_view",
           label = NULL,
-          choices = NULL,
-          options = list(
-            placeholder = "Type a player name",
-            openOnFocus = FALSE,
-            closeAfterSelect = TRUE,
-            maxOptions = 5,
-            onDropdownOpen = I("function(dropdown) { if (!this.lastQuery.length) { this.close(); } }")
-          ),
-          width = "100%"
+          choices = c("Single Player" = "single", "Compare Players" = "compare"),
+          selected = "single",
+          inline = TRUE
         )
       ),
-      uiOutput("player_preview")
+      conditionalPanel(
+        condition = "input.analysis_view === 'single'",
+        div(
+          class = "search-input-container",
+          selectizeInput(
+            inputId = "player_selection",
+            label = NULL,
+            choices = NULL,
+            options = list(
+              placeholder = "Type a player name",
+              openOnFocus = FALSE,
+              closeAfterSelect = TRUE,
+              maxOptions = 5,
+              onDropdownOpen = I("function(dropdown) { if (!this.lastQuery.length) { this.close(); } }")
+            ),
+            width = "100%"
+          )
+        ),
+        uiOutput("player_preview")
+      ),
+      conditionalPanel(
+        condition = "input.analysis_view === 'compare'",
+        tagList(
+          radioButtons(
+            "compare_type",
+            "Player Type",
+            choices = c("Hitters" = "hitter", "Pitchers" = "pitcher"),
+            inline = TRUE
+          ),
+          fluidRow(
+            column(
+              4,
+              selectizeInput(
+                "compare_player1",
+                "Player 1",
+                choices = NULL,
+                options = list(placeholder = "Select player"),
+                width = "100%"
+              )
+            ),
+            column(
+              4,
+              selectizeInput(
+                "compare_player2",
+                "Player 2",
+                choices = NULL,
+                options = list(placeholder = "Select player"),
+                width = "100%"
+              )
+            ),
+            column(
+              4,
+              selectizeInput(
+                "compare_player3",
+                "Player 3",
+                choices = NULL,
+                options = list(placeholder = "Select player"),
+                width = "100%"
+              )
+            )
+          )
+        )
+      )
     ),
 
     # Step 2: Analysis Style
@@ -489,79 +545,6 @@ ui <- page_navbar(
     uiOutput("step_3_analysis_results")
   ),
 
-  nav_panel(
-    title = "Compare",
-    icon = icon("users"),
-    div(
-      class = "container mt-4",
-      div(
-        class = "step-card active",
-        div(
-          class = "step-header",
-          div(class = "step-number", "1"),
-          h3(class = "step-title", "Select Players")
-        ),
-        radioButtons(
-          "compare_type",
-          "Player Type",
-          choices = c("Hitters" = "hitter", "Pitchers" = "pitcher"),
-          inline = TRUE
-        ),
-        fluidRow(
-          column(
-            4,
-            selectizeInput(
-              "compare_player1",
-              "Player 1",
-              choices = NULL,
-              options = list(placeholder = "Select player"),
-              width = "100%"
-            )
-          ),
-          column(
-            4,
-            selectizeInput(
-              "compare_player2",
-              "Player 2",
-              choices = NULL,
-              options = list(placeholder = "Select player"),
-              width = "100%"
-            )
-          ),
-          column(
-            4,
-            selectizeInput(
-              "compare_player3",
-              "Player 3",
-              choices = NULL,
-              options = list(placeholder = "Select player"),
-              width = "100%"
-            )
-          )
-        )
-      ),
-      div(
-        class = "step-card active",
-        div(
-          class = "step-header",
-          div(class = "step-number", "2"),
-          h3(class = "step-title", "Analysis")
-        ),
-        actionButton(
-          "compare_analyze",
-          "Analyze",
-          icon = icon("robot"),
-          class = "btn-primary mb-3",
-          onclick = "document.getElementById('compare-results').scrollIntoView({behavior: 'smooth', block: 'start'});"
-        ),
-        div(
-          id = "compare-results",
-          uiOutput("compare_results"),
-          uiOutput("compare_ai")
-        )
-      )
-    )
-  ),
 
   nav_panel(
     title = "About",

--- a/app/ui.R
+++ b/app/ui.R
@@ -488,6 +488,7 @@ ui <- page_navbar(
               maxOptions = 5,
               onDropdownOpen = I("function(dropdown) { if (!this.lastQuery.length) { this.close(); } }")
             ),
+            server = TRUE,
             width = "100%"
           )
         ),
@@ -510,6 +511,7 @@ ui <- page_navbar(
                 "Player 1",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
+                server = TRUE,
                 width = "100%"
               )
             ),
@@ -520,6 +522,7 @@ ui <- page_navbar(
                 "Player 2",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
+                server = TRUE,
                 width = "100%"
               )
             ),
@@ -530,6 +533,7 @@ ui <- page_navbar(
                 "Player 3",
                 choices = NULL,
                 options = list(placeholder = "Select player"),
+                server = TRUE,
                 width = "100%"
               )
             )

--- a/tests/testthat/test_app.R
+++ b/tests/testthat/test_app.R
@@ -52,6 +52,12 @@ test_that("call_openai_api handles missing API key", {
   expect_true(grepl("OpenAI API Key Not Set", as.character(result)))
 })
 
+test_that("call_openai_api supports comparison context without API access", {
+  Sys.setenv(OPENAI_API_KEY = "")
+  result <- call_openai_api("Player A: AVG .300", "default", context = "comparison")
+  expect_true(grepl("Rank the players", as.character(result), ignore.case = TRUE))
+})
+
 test_that("prompt builders return text when player exists", {
   data <- load_local_data()
   hitter_name <- data$hitters$Name[1]


### PR DESCRIPTION
## Summary
- Consolidate the analysis and comparison workflows into a single guided experience with a mode toggle so users stay on one navigation surface.
- Load comparison selections from shared links, trigger the comparison run automatically, and render the cards plus AI narrative within the step-based layout.
- Generate clean shareable URLs that capture the active view, players, and vibe and reuse them for the X share link.

## Testing
- `Rscript run_tests.R` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c961975344832b8b80235ff1e2d4fb