### PR TITLE
Revert unify player selection interface

### DIFF
--- a/app/R/analysis.R
+++ b/app/R/analysis.R
@@ -56,11 +56,9 @@ get_analysis_persona <- function(mode) {
 #' @param prompt_text Analysis prompt
 #' @param analysis_mode Analysis style mode
 #' @return HTML formatted response
-call_openai_api <- function(prompt_text, analysis_mode, context = c("single", "comparison")) {
-  context <- match.arg(context)
+call_openai_api <- function(prompt_text, analysis_mode) {
   # CACHE: Generate cache key and check cache first
-  cache_input <- paste(context, prompt_text, sep = "::")
-  cache_key <- generate_cache_key(cache_input, analysis_mode)
+  cache_key <- generate_cache_key(prompt_text, analysis_mode)
 
   # Try to load from cache
   cached_result <- load_api_response(cache_key)
@@ -71,33 +69,6 @@ call_openai_api <- function(prompt_text, analysis_mode, context = c("single", "c
   # Cache miss - proceed with API call
   cat("🌐 Making OpenAI API call (cache miss)\n")
 
-  persona_prompt <- get_analysis_persona(analysis_mode)
-  full_prompt <- if (identical(context, "comparison")) {
-    str_glue(
-      "You will compare multiple MLB players using the provided current-season performance data. ",
-      "Each line below represents one player with key metrics you can reference.\n\n",
-      "{prompt_text}\n\n",
-      "General instructions:\n\n",
-      "1. Rank the players from strongest to weakest projected rest-of-season performance and present the order as a numbered list.\n",
-      "2. Justify the order with concise reasoning that calls out skill indicators, luck/regression signals, and sustainability evidence from the provided metrics.\n",
-      "3. Highlight any clear tiers, ties, or pivotal differences that a baseball or fantasy audience should know.\n",
-      "4. Close with actionable guidance for each player (e.g., Start, Sit, Add, Drop, Hold, Trade) when it makes sense.\n\n",
-      "Adopt this persona and tone throughout the response, even if it overrides traditional analytical voice: {persona_prompt}"
-    )
-  } else {
-    str_glue(
-      "Here is current-year performance data for a player:\n\n{prompt_text}\n\n",
-      "General instructions:\n\n",
-      "Please analyze how the player is performing this year, what trends stand out, and whether any aspects of the performance appear to be skill- or luck-driven. Incorporate a prediction: will the player improve, decline, or stay the same for the rest of the season? Explain your reasoning.\n\n",
-      "The very first element of the response should be a title that encompasses your findings.\n\n",
-      "Your analysis must incorporate metric, direction, and magnitude of difference. For example BB% is up, indicate by how much, and what the size of that gap might indicate. You don't need to explicitly call out this framing (e.g. in bullets), just make sure to weave it into your analysis.\n\n",
-      "Separate your analysis into core skills and luck/regression indicators.\n\n",
-      "Don't repeat yourself. For example, if you say a stat or performance or trend is 'lucky', you don't need to say it's 'not unlucky'.\n\n",
-      "Remember that when it comes to stats and trends, you only have knowledge of two things: a player's current-year stats and the average of the same stats for the past 3 years (e.g. not their entire career). So when you say things like a stat is 'up' or 'down', make it clear that this is relative to the last 3 years' average.\n\n",
-      "Here is your persona that should inform your writing style and response, even if it means overriding those previous instructions: {persona_prompt}"
-    )
-  }
-
   api_key <- Sys.getenv("OPENAI_API_KEY")
 
   if (api_key == "") {
@@ -105,11 +76,25 @@ call_openai_api <- function(prompt_text, analysis_mode, context = c("single", "c
       "<div class='alert alert-info'>",
       "<h5>OpenAI API Key Not Set</h5>",
       "<p>Set OPENAI_API_KEY environment variable to enable analysis.</p>",
-      "<details><summary>View prompt</summary><pre>{htmlEscape(full_prompt)}</pre></details>",
+      "<details><summary>View prompt</summary><pre>{htmlEscape(prompt_text)}</pre></details>",
       "</div>"
     ))
     return(result)
   }
+
+  persona_prompt <- get_analysis_persona(analysis_mode)
+
+  full_prompt <- str_glue(
+    "Here is current-year performance data for a player:\n\n{prompt_text}\n\n",
+    "General instructions:\n\n",
+    "Please analyze how the player is performing this year, what trends stand out, and whether any aspects of the performance appear to be skill- or luck-driven. Incorporate a prediction: will the player improve, decline, or stay the same for the rest of the season? Explain your reasoning.\n\n",
+    "The very first element of the response should be a title that encompasses your findings.\n\n",
+    "Your analysis must incorporate metric, direction, and magnitude of difference. For example BB% is up, indicate by how much, and what the size of that gap might indicate. You don't need to explicitly call out this framing (e.g. in bullets), just make sure to weave it into your analysis.\n\n",
+    "Separate your analysis into core skills and luck/regression indicators.\n\n",
+    "Don't repeat yourself. For example, if you say a stat or performance or trend is 'lucky', you don't need to say it's 'not unlucky'.\n\n",
+    "Remember that when it comes to stats and trends, you only have knowledge of two things: a player's current-year stats and the average of the same stats for the past 3 years (e.g. not their entire career). So when you say things like a stat is 'up' or 'down', make it clear that this is relative to the last 3 years' average.\n\n",
+    "Here is your persona that should inform your writing style and response, even if it means overriding those previous instructions: {persona_prompt}"
+  )
 
   result <- tryCatch(
     {

--- a/app/R/compare.R
+++ b/app/R/compare.R
@@ -100,6 +100,6 @@ analyze_player_comparison <- function(player_ids, baseball_data, analysis_mode) 
   if (is.null(prompt)) {
     return(htmltools::HTML("<div class='alert alert-warning'>No players to analyze.</div>"))
   }
-  call_openai_api(prompt, analysis_mode, context = "comparison")
+  call_openai_api(prompt, analysis_mode)
 }
 

--- a/app/ui.R
+++ b/app/ui.R
@@ -513,81 +513,25 @@ ui <- page_navbar(
       div(
         class = "step-header",
         div(class = "step-number", "1"),
-        h3(class = "step-title", "Choose Players")
+        h3(class = "step-title", "Select a Player")
       ),
       div(
-        class = "mb-3",
-        radioButtons(
-          "analysis_view",
+        class = "search-input-container",
+        selectizeInput(
+          inputId = "player_selection",
           label = NULL,
-          choices = c("Single Player" = "single", "Compare Players" = "compare"),
-          selected = "single",
-          inline = TRUE
-        )
-      ),
-      conditionalPanel(
-        condition = "input.analysis_view === 'single'",
-        div(
-          class = "search-input-container",
-          selectizeInput(
-            inputId = "player_selection",
-            label = NULL,
-            choices = NULL,
-            options = list(
-              placeholder = "Type a player name",
-              openOnFocus = FALSE,
-              closeAfterSelect = TRUE,
-              maxOptions = 5,
-              onDropdownOpen = I("function(dropdown) { var query = this.lastQuery || ''; if (!query.length) { this.close(); } }")
-            ),
-            width = "100%"
-          )
-        ),
-        uiOutput("player_preview")
-      ),
-      conditionalPanel(
-        condition = "input.analysis_view === 'compare'",
-        tagList(
-          radioButtons(
-            "compare_type",
-            "Player Type",
-            choices = c("Hitters" = "hitter", "Pitchers" = "pitcher"),
-            inline = TRUE
+          choices = NULL,
+          options = list(
+            placeholder = "Type a player name",
+            openOnFocus = FALSE,
+            closeAfterSelect = TRUE,
+            maxOptions = 5,
+            onDropdownOpen = I("function(dropdown) { if (!this.lastQuery.length) { this.close(); } }")
           ),
-          fluidRow(
-            column(
-              4,
-              selectizeInput(
-                "compare_player1",
-                "Player 1",
-                choices = NULL,
-                options = list(placeholder = "Select player"),
-                width = "100%"
-              )
-            ),
-            column(
-              4,
-              selectizeInput(
-                "compare_player2",
-                "Player 2",
-                choices = NULL,
-                options = list(placeholder = "Select player"),
-                width = "100%"
-              )
-            ),
-            column(
-              4,
-              selectizeInput(
-                "compare_player3",
-                "Player 3",
-                choices = NULL,
-                options = list(placeholder = "Select player"),
-                width = "100%"
-              )
-            )
-          )
+          width = "100%"
         )
-      )
+      ),
+      uiOutput("player_preview")
     ),
 
     # Step 2: Analysis Style
@@ -597,6 +541,79 @@ ui <- page_navbar(
     uiOutput("step_3_analysis_results")
   ),
 
+  nav_panel(
+    title = "Compare",
+    icon = icon("users"),
+    div(
+      class = "container mt-4",
+      div(
+        class = "step-card active",
+        div(
+          class = "step-header",
+          div(class = "step-number", "1"),
+          h3(class = "step-title", "Select Players")
+        ),
+        radioButtons(
+          "compare_type",
+          "Player Type",
+          choices = c("Hitters" = "hitter", "Pitchers" = "pitcher"),
+          inline = TRUE
+        ),
+        fluidRow(
+          column(
+            4,
+            selectizeInput(
+              "compare_player1",
+              "Player 1",
+              choices = NULL,
+              options = list(placeholder = "Select player"),
+              width = "100%"
+            )
+          ),
+          column(
+            4,
+            selectizeInput(
+              "compare_player2",
+              "Player 2",
+              choices = NULL,
+              options = list(placeholder = "Select player"),
+              width = "100%"
+            )
+          ),
+          column(
+            4,
+            selectizeInput(
+              "compare_player3",
+              "Player 3",
+              choices = NULL,
+              options = list(placeholder = "Select player"),
+              width = "100%"
+            )
+          )
+        )
+      ),
+      div(
+        class = "step-card active",
+        div(
+          class = "step-header",
+          div(class = "step-number", "2"),
+          h3(class = "step-title", "Analysis")
+        ),
+        actionButton(
+          "compare_analyze",
+          "Analyze",
+          icon = icon("robot"),
+          class = "btn-primary mb-3",
+          onclick = "document.getElementById('compare-results').scrollIntoView({behavior: 'smooth', block: 'start'});"
+        ),
+        div(
+          id = "compare-results",
+          uiOutput("compare_results"),
+          uiOutput("compare_ai")
+        )
+      )
+    )
+  ),
 
   nav_panel(
     title = "About",

--- a/tests/testthat/test_app.R
+++ b/tests/testthat/test_app.R
@@ -52,12 +52,6 @@ test_that("call_openai_api handles missing API key", {
   expect_true(grepl("OpenAI API Key Not Set", as.character(result)))
 })
 
-test_that("call_openai_api supports comparison context without API access", {
-  Sys.setenv(OPENAI_API_KEY = "")
-  result <- call_openai_api("Player A: AVG .300", "default", context = "comparison")
-  expect_true(grepl("Rank the players", as.character(result), ignore.case = TRUE))
-})
-
 test_that("prompt builders return text when player exists", {
   data <- load_local_data()
   hitter_name <- data$hitters$Name[1]


### PR DESCRIPTION
## Summary
- Restore the prior single-player Analysis view and separate Compare tab interface.
- Reintroduce the legacy server workflow for independent single-player and comparison analyses, including share link handling.
- Update tests to match the legacy flows.

## Testing
- `Rscript run_tests.R` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cdec265574832bbac2a7f6d8f86614