### PR TITLE
Capture analytics events for sessions, analyses, and shares

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 client/dist
 server/dist
+analytics*.db
 .env
 coverage
 playwright-report
@@ -36,4 +37,3 @@ app/.Renviron
 *.jpg
 *.numbers
 .DS_Store
-node_modules

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,10 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import SinglePlayerPage from "./pages/SinglePlayerPage";
 import ComparePage from "./pages/ComparePage";
 import AboutPage from "./pages/AboutPage";
 import { VibeProvider } from "./contexts/VibeContext";
 import styles from "./styles/App.module.css";
+import { registerSession } from "./api";
 
 type ExperienceMode = "single" | "compare";
 type View = "experience" | "about";
@@ -11,6 +12,10 @@ type View = "experience" | "about";
 function App() {
   const [mode, setMode] = useState<ExperienceMode>("single");
   const [view, setView] = useState<View>("experience");
+
+  useEffect(() => {
+    void registerSession();
+  }, []);
 
   return (
     <VibeProvider>

--- a/server/src/analytics.ts
+++ b/server/src/analytics.ts
@@ -1,8 +1,328 @@
-export async function logSessionStart(sessionId: string): Promise<void> {
+import path from "node:path";
+import sqlite3 from "sqlite3";
+import { Pool } from "pg";
+
+const SQLITE_DB_NAME = "analytics.db";
+const SQLITE_FALLBACK_DB_NAME = "analytics_fallback.db";
+
+type DatabaseDriver =
+  | { type: "postgres"; pool: Pool }
+  | { type: "sqlite"; db: sqlite3.Database };
+
+let driverPromise: Promise<DatabaseDriver> | null = null;
+let initializationPromise: Promise<void> | null = null;
+
+function getAdminPassword(): string | undefined {
+  const password = process.env.ADMIN_PASSWORD;
+  if (!password || password.trim().length === 0) {
+    return undefined;
+  }
+  return password;
+}
+
+function containsAdminSecret(value: string | null | undefined): boolean {
+  const adminPassword = getAdminPassword();
+  if (!adminPassword) {
+    return false;
+  }
+  if (!value) {
+    return false;
+  }
+
+  const encoded = encodeURIComponent(adminPassword);
+  if (value.includes(`admin=${adminPassword}`) || value.includes(`admin=${encoded}`)) {
+    return true;
+  }
+
+  try {
+    const decoded = decodeURIComponent(value);
+    return decoded.includes(`admin=${adminPassword}`);
+  } catch (_error) {
+    return false;
+  }
+}
+
+function shouldSkipLogging(...sources: Array<string | null | undefined>): boolean {
+  return sources.some((source) => containsAdminSecret(source));
+}
+
+async function createSqliteDriver(): Promise<DatabaseDriver> {
+  const isRender = process.env.RENDER === "true";
+  const dbName = isRender ? SQLITE_FALLBACK_DB_NAME : SQLITE_DB_NAME;
+  const dbPath = path.resolve(process.cwd(), dbName);
+  const sqlite = sqlite3.verbose();
+
+  const db = await new Promise<sqlite3.Database>((resolve, reject) => {
+    const instance = new sqlite.Database(dbPath, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve(instance);
+      }
+    });
+  });
+
+  console.info(`[analytics] using SQLite database at ${dbPath}`);
+  return { type: "sqlite", db };
+}
+
+async function createPostgresDriver(databaseUrl: string): Promise<DatabaseDriver> {
+  const pool = new Pool({
+    connectionString: databaseUrl,
+    ssl:
+      databaseUrl.includes("render.com") || process.env.NODE_ENV === "production"
+        ? { rejectUnauthorized: false }
+        : undefined,
+  });
+
+  await pool.query("SELECT 1");
+  console.info("[analytics] connected to PostgreSQL database");
+  return { type: "postgres", pool };
+}
+
+async function getDriver(): Promise<DatabaseDriver> {
+  if (!driverPromise) {
+    driverPromise = (async () => {
+      const databaseUrl = process.env.DATABASE_URL;
+      if (databaseUrl && databaseUrl.trim().length > 0) {
+        try {
+          return await createPostgresDriver(databaseUrl);
+        } catch (error) {
+          console.warn("[analytics] failed to connect to PostgreSQL, falling back to SQLite", error);
+        }
+      }
+
+      return createSqliteDriver();
+    })();
+  }
+
+  return driverPromise;
+}
+
+function runSqlite(db: sqlite3.Database, sql: string, params: unknown[] = []): Promise<void> {
+  return new Promise((resolve, reject) => {
+    db.run(sql, params, function (error) {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function runStatement(sqliteSql: string, postgresSql: string, params: unknown[] = []): Promise<void> {
+  const driver = await getDriver();
+
+  if (driver.type === "postgres") {
+    await driver.pool.query(postgresSql, params);
+  } else {
+    await runSqlite(driver.db, sqliteSql, params);
+  }
+}
+
+function truncate(value: string | null | undefined, maxLength: number): string | null {
+  if (!value) {
+    return null;
+  }
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return value.slice(0, maxLength);
+}
+
+export async function initializeAnalytics(): Promise<void> {
+  if (!initializationPromise) {
+    initializationPromise = (async () => {
+      await runStatement(
+        `CREATE TABLE IF NOT EXISTS sessions (
+          session_id TEXT,
+          referer TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`,
+        `CREATE TABLE IF NOT EXISTS sessions (
+          session_id TEXT,
+          referer TEXT,
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )`
+      );
+
+      await runStatement(
+        `CREATE TABLE IF NOT EXISTS analyses (
+          session_id TEXT,
+          player_label TEXT,
+          analysis_mode TEXT,
+          event_type TEXT,
+          player_type TEXT,
+          referer TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`,
+        `CREATE TABLE IF NOT EXISTS analyses (
+          session_id TEXT,
+          player_label TEXT,
+          analysis_mode TEXT,
+          event_type TEXT,
+          player_type TEXT,
+          referer TEXT,
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )`
+      );
+
+      await runStatement(
+        `CREATE TABLE IF NOT EXISTS share_events (
+          session_id TEXT,
+          player_label TEXT,
+          analysis_mode TEXT,
+          event_type TEXT,
+          player_type TEXT,
+          share_url TEXT,
+          referer TEXT,
+          created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+        )`,
+        `CREATE TABLE IF NOT EXISTS share_events (
+          session_id TEXT,
+          player_label TEXT,
+          analysis_mode TEXT,
+          event_type TEXT,
+          player_type TEXT,
+          share_url TEXT,
+          referer TEXT,
+          created_at TIMESTAMPTZ DEFAULT NOW()
+        )`
+      );
+
+      await runStatement(
+        `CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions(date(created_at))`,
+        `CREATE INDEX IF NOT EXISTS idx_sessions_created_at ON sessions((created_at::date))`
+      );
+
+      await runStatement(
+        `CREATE INDEX IF NOT EXISTS idx_analyses_created_at ON analyses(date(created_at))`,
+        `CREATE INDEX IF NOT EXISTS idx_analyses_created_at ON analyses((created_at::date))`
+      );
+
+      await runStatement(
+        `CREATE INDEX IF NOT EXISTS idx_share_events_created_at ON share_events(date(created_at))`,
+        `CREATE INDEX IF NOT EXISTS idx_share_events_created_at ON share_events((created_at::date))`
+      );
+    })().catch((error) => {
+      console.warn("[analytics] failed to initialize analytics storage", error);
+    });
+  }
+
+  try {
+    await initializationPromise;
+  } catch (_error) {
+    // Initialization failure already logged; continue without blocking requests.
+  }
+}
+
+type AnalysisLogEvent = {
+  sessionId: string;
+  playerLabel: string;
+  analysisMode: string;
+  playerType: "hitter" | "pitcher";
+  eventType: "single" | "compare";
+  referer?: string | null;
+};
+
+type ShareLogEvent = {
+  sessionId: string;
+  playerLabel: string;
+  analysisMode: string;
+  eventType: string;
+  playerType?: "hitter" | "pitcher";
+  shareUrl?: string | null;
+  referer?: string | null;
+};
+
+export async function logSessionStart(sessionId: string, referer?: string | null): Promise<void> {
   if (!sessionId) {
     return;
   }
+  if (shouldSkipLogging(referer)) {
+    return;
+  }
 
-  const timestamp = new Date().toISOString();
-  console.info(`[analytics] session started`, { sessionId, timestamp });
+  try {
+    await initializeAnalytics();
+    await runStatement(
+      `INSERT INTO sessions (session_id, referer) VALUES (?, ?)`,
+      `INSERT INTO sessions (session_id, referer) VALUES ($1, $2)`,
+      [sessionId, truncate(referer, 512)]
+    );
+    console.info("[analytics] session started", { sessionId });
+  } catch (error) {
+    console.warn("[analytics] failed to log session start", error);
+  }
+}
+
+export async function logAnalysisEvent(event: AnalysisLogEvent): Promise<void> {
+  if (!event.sessionId) {
+    return;
+  }
+  if (shouldSkipLogging(event.referer)) {
+    return;
+  }
+
+  try {
+    await initializeAnalytics();
+    await runStatement(
+      `INSERT INTO analyses (session_id, player_label, analysis_mode, event_type, player_type, referer)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO analyses (session_id, player_label, analysis_mode, event_type, player_type, referer)
+       VALUES ($1, $2, $3, $4, $5, $6)` ,
+      [
+        event.sessionId,
+        truncate(event.playerLabel, 256),
+        truncate(event.analysisMode, 64),
+        event.eventType,
+        event.playerType,
+        truncate(event.referer, 512),
+      ]
+    );
+    console.info("[analytics] analysis logged", {
+      sessionId: event.sessionId,
+      playerLabel: event.playerLabel,
+      analysisMode: event.analysisMode,
+      eventType: event.eventType,
+    });
+  } catch (error) {
+    console.warn("[analytics] failed to log analysis", error);
+  }
+}
+
+export async function logShareEvent(event: ShareLogEvent): Promise<void> {
+  if (!event.sessionId) {
+    return;
+  }
+  if (shouldSkipLogging(event.referer, event.shareUrl)) {
+    return;
+  }
+
+  try {
+    await initializeAnalytics();
+    await runStatement(
+      `INSERT INTO share_events (session_id, player_label, analysis_mode, event_type, player_type, share_url, referer)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      `INSERT INTO share_events (session_id, player_label, analysis_mode, event_type, player_type, share_url, referer)
+       VALUES ($1, $2, $3, $4, $5, $6, $7)` ,
+      [
+        event.sessionId,
+        truncate(event.playerLabel, 256),
+        truncate(event.analysisMode, 64),
+        truncate(event.eventType, 64),
+        event.playerType ?? null,
+        truncate(event.shareUrl ?? null, 1024),
+        truncate(event.referer, 512),
+      ]
+    );
+    console.info("[analytics] share event logged", {
+      sessionId: event.sessionId,
+      eventType: event.eventType,
+      playerLabel: event.playerLabel,
+    });
+  } catch (error) {
+    console.warn("[analytics] failed to log share event", error);
+  }
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,11 +6,14 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import router from "./routes.js";
+import { initializeAnalytics } from "./analytics.js";
 
 const currentDir = path.dirname(fileURLToPath(import.meta.url));
 
 export function createServer() {
   const app = express();
+
+  void initializeAnalytics();
 
   // Allow Express to respect proxy headers (Render/Heroku set X-Forwarded-For)
   const trustProxy = process.env.TRUST_PROXY ?? "1";

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -4,7 +4,7 @@ import { z } from "zod";
 import { buildAboutContent, buildAnalysisPrompt, buildComparisonPrompt, generateQuickInsight, recommendBestPlayer } from "./analysis.js";
 import { callOpenAiChat } from "./openai.js";
 import { getPlayerById, getPlayerSummaries } from "./dataStore.js";
-import { logSessionStart } from "./analytics.js";
+import { logAnalysisEvent, logSessionStart, logShareEvent } from "./analytics.js";
 import { AnalysisMode, ANALYSIS_VIBES, DEFAULT_ANALYSIS_MODE } from "./vibes.js";
 
 const analyzeLimiter = rateLimit({
@@ -32,7 +32,7 @@ router.post("/api/sessions", async (req, res) => {
     return res.status(400).json({ error: "Invalid request body" });
   }
 
-  await logSessionStart(parseResult.data.sessionId);
+  await logSessionStart(parseResult.data.sessionId, req.get("referer"));
   res.status(204).end();
 });
 
@@ -98,6 +98,15 @@ router.post("/api/analyze", analyzeLimiter, async (req, res) => {
   const persona = ANALYSIS_VIBES[mode];
 
   const response = await callOpenAiChat(prompt, persona, mode);
+  const sessionId = req.get("x-session-id") ?? "";
+  await logAnalysisEvent({
+    sessionId,
+    playerLabel: player.Name,
+    analysisMode: mode,
+    playerType,
+    eventType: "single",
+    referer: req.get("referer"),
+  });
   res.json(response);
 });
 
@@ -148,7 +157,46 @@ router.post("/api/compare/analyze", analyzeLimiter, async (req, res) => {
   const persona = ANALYSIS_VIBES[mode];
   const response = await callOpenAiChat(prompt, persona, mode);
 
+  const sessionId = req.get("x-session-id") ?? "";
+  const playerLabel = players.map((entry) => entry.Name).filter(Boolean).join(" vs ");
+  await logAnalysisEvent({
+    sessionId,
+    playerLabel: playerLabel || players.map((entry) => entry.PlayerId).join(" vs "),
+    analysisMode: mode,
+    playerType,
+    eventType: "compare",
+    referer: req.get("referer"),
+  });
+
   res.json(response);
+});
+
+router.post("/api/share-events", async (req, res) => {
+  const schema = z.object({
+    sessionId: z.string().min(1).max(128),
+    playerName: z.string().min(1).max(256),
+    analysisMode: z.string().min(1).max(64),
+    eventType: z.string().min(1).max(64),
+    playerType: playerTypeSchema.optional(),
+    shareUrl: z.string().max(2048).optional(),
+  });
+
+  const parseResult = schema.safeParse(req.body);
+  if (!parseResult.success) {
+    return res.status(400).json({ error: "Invalid request body" });
+  }
+
+  await logShareEvent({
+    sessionId: parseResult.data.sessionId,
+    playerLabel: parseResult.data.playerName,
+    analysisMode: parseResult.data.analysisMode,
+    eventType: parseResult.data.eventType,
+    playerType: parseResult.data.playerType,
+    shareUrl: parseResult.data.shareUrl,
+    referer: req.get("referer"),
+  });
+
+  res.status(204).end();
 });
 
 router.get("/api/vibes", (_req, res) => {

--- a/server/test/routes.test.ts
+++ b/server/test/routes.test.ts
@@ -61,4 +61,17 @@ describe("McFarland API", () => {
     expect(response.body.vibes).toHaveLength(9);
     expect(response.body.defaultMode).toBe("straightforward");
   });
+
+  it("accepts share analytics events", async () => {
+    const response = await request(app)
+      .post("/api/share-events")
+      .send({
+        sessionId: "test-session",
+        playerName: "Test Player",
+        analysisMode: "default",
+        eventType: "share_click",
+      });
+
+    expect(response.status).toBe(204);
+  });
 });


### PR DESCRIPTION
## Summary
- initialize the analytics data store and record session, analysis, and share events while skipping admin URLs
- send the client session identifier on API calls, auto-register sessions on load, and expose a helper to log share interactions
- provide an endpoint for share analytics and add coverage to confirm the API accepts these events

## Testing
- npm run test:unit

------
https://chatgpt.com/codex/tasks/task_e_68d7e3fe9e20832bbf11f0b87e43c3d4