### PR TITLE
[codex] Speed up analysis and compare flows

### DIFF
--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -1,6 +1,7 @@
 import {
   AboutContent,
   AnalysisResponse,
+  CompareAnalysisResponse,
   ComparisonResponse,
   DataFreshness,
   HitterRecord,
@@ -56,10 +57,13 @@ async function request<T>(path: string, options?: RequestInit): Promise<T> {
   return (await response.json()) as T;
 }
 
-export async function fetchPlayers(type: PlayerType, query?: string): Promise<PlayerSummary[]> {
+export async function fetchPlayers(type: PlayerType, query?: string, limit?: number): Promise<PlayerSummary[]> {
   const params = new URLSearchParams({ type });
   if (query) {
     params.set("q", query);
+  }
+  if (limit) {
+    params.set("limit", String(limit));
   }
   const data = await request<{ players: PlayerSummary[] }>(`/api/players?${params.toString()}`);
   return data.players;
@@ -84,8 +88,12 @@ export async function comparePlayers<T extends PlayerRecord>(playerType: PlayerT
   });
 }
 
-export async function analyzeComparison(playerType: PlayerType, playerIds: string[], analysisMode: string): Promise<AnalysisResponse> {
-  return request<AnalysisResponse>(`/api/compare/analyze`, {
+export async function analyzeComparison<T extends PlayerRecord>(
+  playerType: PlayerType,
+  playerIds: string[],
+  analysisMode: string
+): Promise<CompareAnalysisResponse<T>> {
+  return request<CompareAnalysisResponse<T>>(`/api/compare/analyze`, {
     method: "POST",
     body: JSON.stringify({ playerType, playerIds, analysisMode }),
   });

--- a/client/src/components/AnalysisPanel.tsx
+++ b/client/src/components/AnalysisPanel.tsx
@@ -32,6 +32,7 @@ function AnalysisPanel({
   modeLabel,
 }: Props) {
   const showAnalysisBody = Boolean(isAnalyzing || analysis);
+  const normalizedHeadline = headline?.replace(/\s+/g, " ").trim();
 
   return (
     <section className={styles.panel} aria-label="AI analysis">
@@ -62,7 +63,7 @@ function AnalysisPanel({
           ) : (
             analysis && (
               <>
-                {headline && <h3 className={styles.headline}>{headline}</h3>}
+                {normalizedHeadline && <h3 className={styles.headline}>{normalizedHeadline}</h3>}
                 <ReactMarkdown>{analysis}</ReactMarkdown>
               </>
             )

--- a/client/src/pages/ComparePage.tsx
+++ b/client/src/pages/ComparePage.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { analyzeComparison, comparePlayers, fetchPlayers, logShareAnalyticsEvent } from "../api";
+import { analyzeComparison, fetchPlayers, logShareAnalyticsEvent } from "../api";
 import { useVibe } from "../contexts/VibeContext";
 import type { PlayerSummary, PlayerType } from "../types";
 import { buildSharePreviewUrl } from "../utils/share";
@@ -27,6 +27,8 @@ interface Props {
 }
 
 const MAX_PLAYERS = 3;
+const SEARCH_MIN_LENGTH = 2;
+const SEARCH_RESULT_LIMIT = 8;
 
 function buildAnalysisKey(payload: ActiveComparison & { vibe: string }) {
   return `${payload.type}|${payload.ids.join(",")}|${payload.vibe}`;
@@ -70,17 +72,17 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
     );
   }, [initialPlayerIds, initialPlayerType]);
 
-  const playersQuery = useQuery({
-    queryKey: ["compare-players", playerType, searchTerm],
-    queryFn: () => fetchPlayers(playerType, searchTerm),
-  });
+  const trimmedSearch = searchTerm.trim();
+  const searchEnabled = trimmedSearch.length >= SEARCH_MIN_LENGTH;
 
-  const compareMutation = useMutation({
-    mutationFn: ({ type, ids }: ActiveComparison) => comparePlayers(type, ids),
+  const playersQuery = useQuery({
+    queryKey: ["compare-players", playerType, trimmedSearch],
+    queryFn: () => fetchPlayers(playerType, trimmedSearch, SEARCH_RESULT_LIMIT),
+    enabled: searchEnabled,
   });
 
   const {
-    mutate: runAnalysis,
+    mutateAsync: runAnalysis,
     reset: resetAnalysis,
     data: analysisData,
     isPending: isAnalysisPending,
@@ -96,23 +98,22 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
   );
 
   const triggerAnalysis = useCallback(
-    (payload: ActiveComparison & { vibe: string }) => {
+    async (payload: ActiveComparison & { vibe: string }) => {
       const key = buildAnalysisKey(payload);
       if (lastAnalysisKeyRef.current === key) {
-        return;
+        return analysisData;
       }
       lastAnalysisKeyRef.current = key;
-      runAnalysis(payload);
+      return runAnalysis(payload);
     },
-    [runAnalysis]
+    [analysisData, runAnalysis]
   );
 
   const clearAnalysisState = useCallback(() => {
     lastAnalysisKeyRef.current = null;
-    compareMutation.reset();
     resetAnalysis();
     setActiveComparison(null);
-  }, [compareMutation, resetAnalysis]);
+  }, [resetAnalysis]);
 
   const handleCompare = useCallback(
     async (
@@ -132,10 +133,11 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
       }
       const typeToUse = options?.type ?? playerType;
       const payload: ActiveComparison = { type: typeToUse, ids };
-      const result = await compareMutation.mutateAsync(payload);
+      const result = await triggerAnalysis({ type: typeToUse, ids, vibe: vibeMode });
       setActiveComparison(payload);
-      lastAnalysisKeyRef.current = null;
-      triggerAnalysis({ ...payload, vibe: vibeMode });
+      if (!result) {
+        return result;
+      }
       if (options?.updateSelection !== false) {
         const detailsMap = new Map(
           result.players.map((player) => [player.PlayerId, { name: player.Name, mlbamid: player.mlbamid ?? null }])
@@ -144,14 +146,14 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
       }
       return result;
     },
-    [selectedPlayers, playerType, compareMutation, triggerAnalysis, vibeMode]
+    [playerType, selectedPlayers, triggerAnalysis, vibeMode]
   );
 
   const handleAddPlayer = useCallback(
     (player: PlayerSummary) => {
       skipNextAutoCompareRef.current = true;
       hasHydratedFromUrl.current = true;
-      if (compareMutation.data) {
+      if (analysisData) {
         clearAnalysisState();
       }
       setSelectedPlayers((current) => {
@@ -161,22 +163,20 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
         return [...current, player];
       });
       setSearchTerm("");
-      lastAnalysisKeyRef.current = null;
     },
-    [clearAnalysisState, compareMutation]
+    [analysisData, clearAnalysisState]
   );
 
   const handleRemovePlayer = useCallback(
     (id: string) => {
       skipNextAutoCompareRef.current = true;
       hasHydratedFromUrl.current = true;
-      if (compareMutation.data) {
+      if (analysisData) {
         clearAnalysisState();
       }
       setSelectedPlayers((current) => current.filter((player) => player.id !== id));
-      lastAnalysisKeyRef.current = null;
     },
-    [clearAnalysisState, compareMutation]
+    [analysisData, clearAnalysisState]
   );
 
   useEffect(() => {
@@ -186,7 +186,7 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
     if (isAnalysisPending) {
       return;
     }
-    triggerAnalysis({ ...activeComparison, vibe: vibeMode });
+    void triggerAnalysis({ ...activeComparison, vibe: vibeMode });
   }, [activeComparison, isAnalysisPending, triggerAnalysis, vibeMode]);
 
   useEffect(() => {
@@ -259,19 +259,13 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
     vibeMode,
   ]);
 
-  const comparisonResult = compareMutation.data;
+  const comparisonResult = analysisData;
   const analysisReady = Boolean(analysisData?.analysis);
   const recommendedPlayerId = comparisonResult?.recommendedPlayerId ?? null;
 
-  const availablePlayers = playersQuery.data ?? [];
-  const trimmedSearch = searchTerm.trim();
+  const availablePlayers = searchEnabled ? playersQuery.data ?? [] : [];
   const canAddMore = selectedPlayers.length < MAX_PLAYERS;
   const hasSelection = selectedPlayers.length > 0;
-  const helperMessage = !trimmedSearch
-    ? hasSelection
-      ? "Search again to add or swap players."
-      : "Start typing to add players."
-    : null;
   const recommendedPlayerName = recommendedPlayerId
     ? comparisonResult?.players.find((player) => player.PlayerId === recommendedPlayerId)?.Name ?? null
     : null;
@@ -383,9 +377,9 @@ function CompareExperience({ initialPlayerType, initialPlayerIds, onStateChange 
           onClick={() => {
             void handleCompare();
           }}
-          disabled={selectedPlayers.length < 2 || compareMutation.isPending}
+          disabled={selectedPlayers.length < 2 || isAnalysisPending}
         >
-          {compareMutation.isPending ? "Comparing…" : "Compare"}
+          {isAnalysisPending ? "Comparing…" : "Compare"}
         </button>
       </section>
 

--- a/client/src/pages/SinglePlayerPage.tsx
+++ b/client/src/pages/SinglePlayerPage.tsx
@@ -26,6 +26,9 @@ interface Props {
   onStateChange: (state: { playerType: PlayerType; playerId?: string }) => void;
 }
 
+const SEARCH_MIN_LENGTH = 2;
+const SEARCH_RESULT_LIMIT = 8;
+
 function formatSlashStat(value: number | null | undefined): string {
   if (value === null || value === undefined || Number.isNaN(value)) {
     return "N/A";
@@ -83,9 +86,13 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
     }
   }, [initialPlayerType, initialPlayerId]);
 
+  const trimmedSearch = searchTerm.trim();
+  const searchEnabled = trimmedSearch.length >= SEARCH_MIN_LENGTH;
+
   const playersQuery = useQuery({
-    queryKey: ["players", playerType, searchTerm],
-    queryFn: () => fetchPlayers(playerType, searchTerm),
+    queryKey: ["players", playerType, trimmedSearch],
+    queryFn: () => fetchPlayers(playerType, trimmedSearch, SEARCH_RESULT_LIMIT),
+    enabled: searchEnabled,
   });
 
   const detailQuery = useQuery({
@@ -237,13 +244,13 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
               setSelectedId(undefined);
             }
           }}
-          players={playersQuery.data ?? []}
+          players={searchEnabled ? playersQuery.data ?? [] : []}
           selectedId={selectedId}
           onSelect={(playerId) => {
             setSelectionSource("main_ui");
             setSelectedId(playerId);
           }}
-          isLoading={playersQuery.isLoading}
+          isLoading={searchEnabled && playersQuery.isLoading}
         />
         <WeeklyTrendsSection
           embedded

--- a/client/src/styles/AnalysisPanel.module.css
+++ b/client/src/styles/AnalysisPanel.module.css
@@ -66,7 +66,9 @@
   font-weight: 800;
   line-height: 1.25;
   letter-spacing: -0.02em;
-  text-wrap: balance;
+  white-space: normal;
+  overflow-wrap: anywhere;
+  text-wrap: wrap;
 }
 
 

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -112,6 +112,11 @@ export interface AnalysisResponse {
   cached: boolean;
 }
 
+export interface CompareAnalysisResponse<T extends PlayerRecord> extends AnalysisResponse {
+  players: T[];
+  recommendedPlayerId: string | null;
+}
+
 export interface Vibe {
   id: string;
   label: string;

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -12,13 +12,19 @@ interface OpenAIResponse {
   cached: boolean;
 }
 
-function buildHeadlinePrompt(analysis: string): string {
+type ParsedAnalysisPayload = {
+  headline: string;
+  analysis: string;
+};
+
+function buildStructuredAnalysisPrompt(prompt: string): string {
   return [
-    "You are a newspaper editor whose job is to distill a detailed baseball analysis into a factual but compelling headline.",
+    prompt,
     "",
-    "Using the analysis below, write a single headline that captures the most important takeaway and makes the reader want to keep reading.",
+    "Return valid JSON only with this exact shape:",
+    '{"headline":"...","analysis":"..."}',
     "",
-    "Requirements:",
+    "For headline:",
     "- Be concise.",
     "- Be specific and grounded in the analysis.",
     "- Use words, not stat notation.",
@@ -29,11 +35,45 @@ function buildHeadlinePrompt(analysis: string): string {
     "- Do not use first-person language.",
     "- Prefer substance over puns.",
     "- Reflect the actual confidence level of the analysis and do not overstate small-sample conclusions.",
-    "- Return only the headline text.",
     "",
-    "Analysis:",
-    analysis,
+    "For analysis:",
+    "- Put the full analysis in the analysis field only.",
+    "- Do not repeat the headline verbatim as the first sentence.",
   ].join("\n");
+}
+
+function parseJsonPayload(text: string): ParsedAnalysisPayload | null {
+  const trimmed = text.trim();
+  const direct = trimmed.match(/^\{[\s\S]*\}$/);
+  const candidate = direct?.[0] ?? trimmed.match(/```json\s*([\s\S]*?)```/i)?.[1] ?? trimmed.match(/```([\s\S]*?)```/)?.[1];
+
+  if (!candidate) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(candidate) as Partial<ParsedAnalysisPayload>;
+    if (typeof parsed.headline !== "string" || typeof parsed.analysis !== "string") {
+      return null;
+    }
+    return {
+      headline: parsed.headline.trim(),
+      analysis: parsed.analysis.trim(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildFallbackHeadline(analysis: string): string {
+  const normalized = analysis
+    .replace(/^#+\s*/gm, "")
+    .replace(/\*\*/g, "")
+    .trim();
+  const firstLine = normalized.split(/\n+/).find((line) => line.trim().length > 0)?.trim() ?? "";
+  const firstSentence = firstLine.split(/(?<=[.!?])\s+/)[0]?.trim() ?? "";
+  const candidate = (firstSentence || firstLine).replace(/[.!?]+$/, "").trim();
+  return candidate || "Analysis available";
 }
 
 async function runChatCompletion(apiKey: string, prompt: string): Promise<string> {
@@ -87,8 +127,10 @@ export async function callOpenAiChat(prompt: string, persona: string, mode: Anal
   }
 
   try {
-    const analysis = await runChatCompletion(apiKey, prompt);
-    const headline = await runChatCompletion(apiKey, buildHeadlinePrompt(analysis));
+    const payload = await runChatCompletion(apiKey, buildStructuredAnalysisPrompt(prompt));
+    const parsed = parseJsonPayload(payload);
+    const analysis = parsed?.analysis || payload;
+    const headline = parsed?.headline || buildFallbackHeadline(analysis);
 
     cache.set(cacheKey, { analysis, headline, persona, timestamp: Date.now() });
 

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -19,12 +19,27 @@ type ParsedAnalysisPayload = {
 
 function buildStructuredAnalysisPrompt(prompt: string): string {
   return [
-    prompt,
+    "You are doing the same two tasks as the previous version of this feature, but you must return both results in one JSON object.",
     "",
-    "Return valid JSON only with this exact shape:",
+    "Task 1: write the full baseball analysis from the prompt below.",
+    "Task 2: then distill that analysis into a factual but compelling headline.",
+    "",
+    "Important:",
+    "- Keep the analysis as tight, controlled, and statistically grounded as the original prompt implies.",
+    "- Do not loosen the tone, broaden the scope, or improvise extra structure just because you are returning JSON.",
+    "- The headline should feel like it was written after reading the completed analysis, not independently.",
+    "- Return raw JSON only. Do not wrap it in markdown fences.",
+    "",
+    "JSON shape:",
     '{"headline":"...","analysis":"..."}',
     "",
+    "Write the analysis first, following the prompt exactly:",
+    "",
+    prompt,
+    "",
     "For headline:",
+    "- You are a newspaper editor whose job is to distill a detailed baseball analysis into a factual but compelling headline.",
+    "- Using the completed analysis, write a single headline that captures the most important takeaway and makes the reader want to keep reading.",
     "- Be concise.",
     "- Be specific and grounded in the analysis.",
     "- Use words, not stat notation.",
@@ -35,10 +50,12 @@ function buildStructuredAnalysisPrompt(prompt: string): string {
     "- Do not use first-person language.",
     "- Prefer substance over puns.",
     "- Reflect the actual confidence level of the analysis and do not overstate small-sample conclusions.",
+    "- Return headline text only inside the headline field.",
     "",
     "For analysis:",
     "- Put the full analysis in the analysis field only.",
     "- Do not repeat the headline verbatim as the first sentence.",
+    "- Do not add extra keys, labels, or commentary.",
   ].join("\n");
 }
 

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -39,8 +39,8 @@ router.post("/api/sessions", async (req, res) => {
     return res.status(204).end();
   }
 
-  await logSessionStart(parseResult.data.sessionId, req.get("referer"));
   res.status(204).end();
+  void logSessionStart(parseResult.data.sessionId, req.get("referer"));
 });
 
 router.get("/api/players", (req, res) => {
@@ -111,8 +111,9 @@ router.post("/api/analyze", analyzeLimiter, async (req, res) => {
   try {
     const response = await callOpenAiChat(prompt, persona, mode);
     const sessionId = req.get("x-session-id") ?? "";
+    res.json(response);
     if (!isAdminModeRequest(req)) {
-      await logAnalysisEvent({
+      void logAnalysisEvent({
         sessionId,
         playerName: player.Name,
         analysisMode: mode,
@@ -121,7 +122,6 @@ router.post("/api/analyze", analyzeLimiter, async (req, res) => {
         referer: req.get("referer"),
       });
     }
-    res.json(response);
   } catch (error) {
     console.error("[api/analyze] OpenAI request failed", error);
     res.status(502).json({ error: "Analysis service temporarily unavailable" });
@@ -173,14 +173,20 @@ router.post("/api/compare/analyze", analyzeLimiter, async (req, res) => {
   const mode = (analysisMode in ANALYSIS_VIBES ? analysisMode : DEFAULT_ANALYSIS_MODE) as AnalysisMode;
   const prompt = buildComparisonPrompt(players, playerType, mode);
   const persona = ANALYSIS_VIBES[mode];
+  const recommendedPlayerId = recommendBestPlayer(players, playerType);
 
   try {
     const response = await callOpenAiChat(prompt, persona, mode);
 
     const sessionId = req.get("x-session-id") ?? "";
     const playerName = players.map((entry) => entry.Name).filter(Boolean).join(" vs ");
+    res.json({
+      ...response,
+      players,
+      recommendedPlayerId,
+    });
     if (!isAdminModeRequest(req)) {
-      await logAnalysisEvent({
+      void logAnalysisEvent({
         sessionId,
         playerName: playerName || players.map((entry) => entry.PlayerId).join(" vs "),
         analysisMode: mode,
@@ -189,8 +195,6 @@ router.post("/api/compare/analyze", analyzeLimiter, async (req, res) => {
         referer: req.get("referer"),
       });
     }
-
-    res.json(response);
   } catch (error) {
     console.error("[api/compare/analyze] OpenAI request failed", error);
     res.status(502).json({ error: "Analysis service temporarily unavailable" });
@@ -212,7 +216,8 @@ router.post("/api/share-events", async (req, res) => {
     return res.status(400).json({ error: "Invalid request body" });
   }
 
-  await logShareEvent({
+  res.status(204).end();
+  void logShareEvent({
     sessionId: parseResult.data.sessionId,
     playerName: parseResult.data.playerName,
     analysisMode: parseResult.data.analysisMode,
@@ -221,8 +226,6 @@ router.post("/api/share-events", async (req, res) => {
     shareUrl: parseResult.data.shareUrl,
     referer: req.get("referer"),
   });
-
-  res.status(204).end();
 });
 
 router.get("/api/vibes", (_req, res) => {


### PR DESCRIPTION
## Summary
Apply the small set of refactors with the highest speed payoff for analysis and compare flows, then tighten the one-call prompt/output behavior to stay closer to the previous style.

## What Changed
- gate player search requests until the user types enough input and cap result counts to the visible list size
- return headline and analysis from a single LLM call instead of doing a second headline-only call
- move analytics logging off the user-visible response path for session, analysis, and share events
- collapse compare mode onto the faster analysis response so the UI no longer waits on an extra compare request before analysis
- tighten the one-call analysis/headline prompt so output stays closer to the previous tone and structure
- normalize headline whitespace and let the headline wrap naturally to its container

## Why
This keeps the Pareto speed gains while pulling the model behavior back toward the tighter pre-refactor output style.

## Validation
- npm run build --workspace server
- npm run build --workspace client
- npm run test --workspace tests/e2e