### PR TITLE
Make Codex PRs easier to review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Codex Workflow Rules
+
+## Branches and PRs
+
+Before creating any new PR branch, always start from a freshly updated `master`:
+
+```bash
+git checkout master
+git fetch origin --prune
+git merge --ff-only origin/master
+git checkout -b <new-branch-name>
+```
+
+All pull requests must be real, non-draft PRs.
+
+PR titles and descriptions should be customer-value focused. Lead with what the user or customer gets from the change, then include implementation notes and test coverage as supporting detail.


### PR DESCRIPTION
## Summary
- adds repo-level Codex instructions so future work starts from an updated master
- requires real, non-draft PRs by default
- asks Codex to write PR titles and descriptions around customer value first, with technical details as support

## Tests
- Not run; documentation-only workflow instruction change.