### PR TITLE
Surface daily newsworthy players for quick analysis

### DIFF
--- a/client/src/components/WeeklyTrendsSection.tsx
+++ b/client/src/components/WeeklyTrendsSection.tsx
@@ -15,6 +15,7 @@ type Props = {
   playerType: PlayerType;
   onSelectPlayer: (selection: {
     playerId: string;
+    playerType?: PlayerType;
     source: "recent_analyze_again" | "main_ui";
     analysisMode?: string;
   }) => void;
@@ -45,6 +46,7 @@ function TrendGroup({
             className={styles.chipButton}
             onClick={() => onSelectPlayer({
               playerId: player.id,
+              playerType: player.type,
               source: "main_ui",
             })}
           >
@@ -154,6 +156,7 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
     (playerType === "hitter" ? trendingQuery.data.hitters : trendingQuery.data.pitchers);
   const trendingPlayers = trendingBucket?.trending ?? [];
   const breakoutPlayers = trendingBucket?.breakouts ?? [];
+  const newsworthyPlayers = trendingQuery.data?.newsworthy ?? [];
   const onFirePlayers = trendBucket?.risers ?? [];
   const iceColdPlayers = trendBucket?.fallers ?? [];
 
@@ -172,6 +175,14 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
         <RecentAnalysesGroup analyses={recentAnalyses} onSelectPlayer={onSelectPlayer} />
         {(trendsQuery.isLoading || trendingQuery.isLoading) && <p className={styles.subhead}>Loading…</p>}
         {(trendsQuery.isError || trendingQuery.isError) && <p className={styles.subhead}>Unable to load quick links right now.</p>}
+        {!trendingQuery.isLoading && !trendingQuery.isError && newsworthyPlayers.length > 0 && (
+          <TrendGroup
+            title="In the News"
+            emoji="📰"
+            players={newsworthyPlayers}
+            onSelectPlayer={onSelectPlayer}
+          />
+        )}
         {!trendingQuery.isLoading && !trendingQuery.isError && breakoutPlayers.length > 0 && (
           <TrendGroup
             title="Breakouts"

--- a/client/src/pages/AboutPage.tsx
+++ b/client/src/pages/AboutPage.tsx
@@ -14,6 +14,7 @@ const ABOUT_SECTIONS = [
   {
     title: "How quick links work",
     items: [
+      "\"In the News\" highlights players showing up in the current MLB news cycle, then uses McFARLAND stats to find the best analysis angle.",
       "\"Breakouts\" highlights players whose underlying skill stats look meaningfully better than their weighted baseline, while discounting tiny samples and obvious luck spikes.",
       "\"On Fire\" shows the players whose recent trend improved the most over the last 7 days compared to the 7 days before that.",
       "\"Ice Cold\" shows the players whose recent trend moved hardest in the wrong direction over that same window.",

--- a/client/src/pages/SinglePlayerPage.tsx
+++ b/client/src/pages/SinglePlayerPage.tsx
@@ -255,8 +255,11 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
         <WeeklyTrendsSection
           embedded
           playerType={playerType}
-          onSelectPlayer={({ playerId, source, analysisMode }) => {
+          onSelectPlayer={({ playerId, playerType: selectedPlayerType, source, analysisMode }) => {
             setSelectionSource(source);
+            if (selectedPlayerType && selectedPlayerType !== playerType) {
+              setPlayerType(selectedPlayerType);
+            }
             if (analysisMode && analysisMode !== mode) {
               setMode(analysisMode);
             }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -207,6 +207,7 @@ export interface WeeklyTrendsResponse {
 
 export interface TrendingQuickLinksResponse {
   generatedAt: string;
+  newsworthy: TrendPlayer[];
   hitters: {
     trending: TrendPlayer[];
     breakouts: TrendPlayer[];

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -398,9 +398,9 @@ router.get("/api/about", (_req, res) => {
   res.json(buildAboutContent());
 });
 
-router.get("/api/trending", (req, res) => {
+router.get("/api/trending", async (req, res) => {
   const baseUrl = `${req.protocol}://${req.get("host")}`;
-  res.json(getTrendingQuickLinks(baseUrl));
+  res.json(await getTrendingQuickLinks(baseUrl));
 });
 
 router.get("/api/admin/social-suggestions", async (req, res) => {

--- a/server/src/socialAssistant.ts
+++ b/server/src/socialAssistant.ts
@@ -22,6 +22,21 @@ type NewsItem = {
   publishedAt?: string;
 };
 
+type NewsSearchItem = NewsItem & {
+  query: string;
+};
+
+type NewsDrivenCandidate = SocialCandidate & {
+  newsScore: number;
+};
+
+type NewsworthyQuickLinkCache = {
+  dataThroughDate: string;
+  players: { id: string; name: string; type: PlayerType; mlbamid?: string | null }[];
+};
+
+let newsworthyQuickLinkCache: NewsworthyQuickLinkCache | null = null;
+
 export type SocialDraftSuggestion = {
   playerId: string;
   playerType: PlayerType;
@@ -46,6 +61,7 @@ export type SocialSuggestionResponse = {
 
 export type TrendingQuickLinksResponse = {
   generatedAt: string;
+  newsworthy: { id: string; name: string; type: PlayerType; mlbamid?: string | null }[];
   hitters: {
     trending: { id: string; name: string; type: "hitter"; mlbamid?: string | null }[];
     breakouts: { id: string; name: string; type: "hitter"; mlbamid?: string | null }[];
@@ -91,6 +107,12 @@ function buildShareUrl(baseUrl: string, playerType: PlayerType, playerId: string
   url.searchParams.set("playerType", playerType);
   url.searchParams.set("playerId", playerId);
   return url.toString();
+}
+
+function buildCandidate(player: HitterRecord | PitcherRecord, baseUrl: string): SocialCandidate {
+  return player.player_type === "hitter"
+    ? buildHitterCandidate(player as HitterRecord, baseUrl)
+    : buildPitcherCandidate(player as PitcherRecord, baseUrl);
 }
 
 function buildHitterCandidate(player: HitterRecord, baseUrl: string): SocialCandidate {
@@ -310,13 +332,28 @@ function extractTag(block: string, tag: string): string | undefined {
   return match?.[1] ? decodeHtml(match[1]) : undefined;
 }
 
-async function fetchPlayerNews(playerName: string): Promise<NewsItem[]> {
+function parseNewsItems(xml: string, query: string, limit: number): NewsSearchItem[] {
+  return [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)]
+    .slice(0, limit)
+    .map((match) => {
+      const block = match[1];
+      return {
+        title: extractTag(block, "title") ?? "",
+        link: extractTag(block, "link") ?? "",
+        source: extractTag(block, "source"),
+        publishedAt: extractTag(block, "pubDate"),
+        query,
+      } satisfies NewsSearchItem;
+    })
+    .filter((item) => item.title && item.link);
+}
+
+async function fetchGoogleNewsRss(query: string, limit: number): Promise<NewsSearchItem[]> {
   if (process.env.NODE_ENV === "test") {
     return [];
   }
 
-  const query = encodeURIComponent(`"${playerName}" MLB OR baseball`);
-  const url = `https://news.google.com/rss/search?q=${query}&hl=en-US&gl=US&ceid=US:en`;
+  const url = `https://news.google.com/rss/search?q=${encodeURIComponent(query)}&hl=en-US&gl=US&ceid=US:en`;
 
   try {
     const response = await fetch(url, {
@@ -330,23 +367,188 @@ async function fetchPlayerNews(playerName: string): Promise<NewsItem[]> {
     }
 
     const xml = await response.text();
-    const items = [...xml.matchAll(/<item>([\s\S]*?)<\/item>/gi)]
-      .slice(0, 3)
-      .map((match) => {
-        const block = match[1];
-        return {
-          title: extractTag(block, "title") ?? "",
-          link: extractTag(block, "link") ?? "",
-          source: extractTag(block, "source"),
-          publishedAt: extractTag(block, "pubDate"),
-        } satisfies NewsItem;
-      })
-      .filter((item) => item.title && item.link);
-
-    return items;
+    return parseNewsItems(xml, query, limit);
   } catch (_error) {
     return [];
   }
+}
+
+async function fetchPlayerNews(playerName: string): Promise<NewsItem[]> {
+  return fetchGoogleNewsRss(`"${playerName}" MLB OR baseball`, 3);
+}
+
+const NEWS_DISCOVERY_QUERIES = [
+  "MLB breakout player",
+  "MLB hot streak player",
+  "MLB slump player",
+  "MLB rookie debut",
+  "MLB call-up prospect",
+  "MLB walk-off homer",
+  "MLB strikeouts pitcher",
+  "fantasy baseball riser",
+] as const;
+
+function normalizeSearchText(value: string): string {
+  return value
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+}
+
+function containsName(text: string, playerName: string): boolean {
+  const normalizedText = ` ${normalizeSearchText(text)} `;
+  const normalizedName = normalizeSearchText(playerName);
+  if (!normalizedName.includes(" ")) {
+    return false;
+  }
+  return normalizedText.includes(` ${normalizedName} `);
+}
+
+function eventSpecificityScore(item: NewsSearchItem): number {
+  const text = normalizeSearchText(`${item.query} ${item.title}`);
+  const eventTerms = [
+    "breakout",
+    "hot streak",
+    "slump",
+    "rookie",
+    "debut",
+    "call up",
+    "prospect",
+    "walk off",
+    "homer",
+    "strikeouts",
+    "riser",
+    "sleeper",
+    "waiver",
+  ];
+  return eventTerms.filter((term) => text.includes(term)).length;
+}
+
+function freshnessScore(publishedAt?: string): number {
+  if (!publishedAt) {
+    return 0.5;
+  }
+  const publishedTime = Date.parse(publishedAt);
+  if (Number.isNaN(publishedTime)) {
+    return 0.5;
+  }
+  const ageHours = Math.max(0, (Date.now() - publishedTime) / 36e5);
+  if (ageHours <= 24) return 3;
+  if (ageHours <= 72) return 2;
+  if (ageHours <= 168) return 1;
+  return 0.25;
+}
+
+function sourceKeyFor(item: NewsItem): string {
+  if (item.source) {
+    return normalizeSearchText(item.source);
+  }
+  try {
+    return normalizeSearchText(new URL(item.link).hostname);
+  } catch {
+    return "unknown";
+  }
+}
+
+function buildPlayerIndex(baseUrl: string): SocialCandidate[] {
+  return [
+    ...listPlayers("hitter").map((player) => buildCandidate(player as HitterRecord, baseUrl)),
+    ...listPlayers("pitcher").map((player) => buildCandidate(player as PitcherRecord, baseUrl)),
+  ];
+}
+
+export function buildNewsDrivenCandidates(
+  newsItems: NewsSearchItem[],
+  playerIndex: SocialCandidate[]
+): NewsDrivenCandidate[] {
+  const byPlayer = new Map<string, { candidate: SocialCandidate; news: NewsSearchItem[]; score: number; sources: Set<string> }>();
+  const sourceUseCount = new Map<string, number>();
+
+  for (const item of newsItems) {
+    const sourceKey = sourceKeyFor(item);
+    if ((sourceUseCount.get(sourceKey) ?? 0) >= 8) {
+      continue;
+    }
+
+    const matchedPlayers = playerIndex.filter((candidate) => containsName(item.title, candidate.playerName)).slice(0, 3);
+    if (matchedPlayers.length === 0) {
+      continue;
+    }
+
+    sourceUseCount.set(sourceKey, (sourceUseCount.get(sourceKey) ?? 0) + 1);
+
+    for (const candidate of matchedPlayers) {
+      const key = `${candidate.playerType}:${candidate.playerId}`;
+      const existing = byPlayer.get(key) ?? {
+        candidate,
+        news: [],
+        score: 0,
+        sources: new Set<string>(),
+      };
+
+      if (existing.sources.has(sourceKey)) {
+        continue;
+      }
+
+      existing.sources.add(sourceKey);
+      if (existing.news.length < 3) {
+        existing.news.push(item);
+      }
+      existing.score += 5 + eventSpecificityScore(item) * 1.5 + freshnessScore(item.publishedAt);
+      byPlayer.set(key, existing);
+    }
+  }
+
+  return [...byPlayer.values()]
+    .map(({ candidate, news, score, sources }) => {
+      const sourceDiversity = sources.size;
+      const mcfarlandSignal = Math.min(Math.log1p(Math.max(candidate.score, 0)) * 2, 8);
+      const newsScore = score + sourceDiversity * 4 + mcfarlandSignal;
+      return {
+        ...candidate,
+        score: newsScore,
+        newsScore,
+        news: news.map(({ query: _query, ...item }) => item),
+        whyNow: `${candidate.playerName} is showing up in today's MLB news cycle, and McFARLAND adds this angle: ${candidate.whyNow}`,
+      };
+    })
+    .sort((a, b) => b.newsScore - a.newsScore);
+}
+
+type NewsDrivenCandidatePoolFetcher = (baseUrl: string) => Promise<SocialCandidate[]>;
+
+let newsDrivenCandidatePoolFetcher: NewsDrivenCandidatePoolFetcher | null = null;
+
+async function fetchNewsDrivenCandidatePool(baseUrl: string): Promise<SocialCandidate[]> {
+  if (newsDrivenCandidatePoolFetcher) {
+    return newsDrivenCandidatePoolFetcher(baseUrl);
+  }
+
+  const feeds = await Promise.all(
+    NEWS_DISCOVERY_QUERIES.map((query) => fetchGoogleNewsRss(query, 10))
+  );
+  const newsCandidates = buildNewsDrivenCandidates(feeds.flat(), buildPlayerIndex(baseUrl));
+  return newsCandidates.slice(0, 10);
+}
+
+function candidateKey(candidate: SocialCandidate): string {
+  return `${candidate.playerType}:${candidate.playerId}`;
+}
+
+function supplementCandidatePool(newsDrivenCandidates: SocialCandidate[], statCandidates: SocialCandidate[]): SocialCandidate[] {
+  const seen = new Set(newsDrivenCandidates.map(candidateKey));
+  const supplements = statCandidates.filter((candidate) => {
+    const key = candidateKey(candidate);
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+
+  return [...newsDrivenCandidates, ...supplements].slice(0, 10);
 }
 
 function buildPrompt(candidates: SocialCandidate[]): string {
@@ -373,8 +575,8 @@ function buildPrompt(candidates: SocialCandidate[]): string {
     "You are helping a solo builder decide what baseball player analysis to post on social media today.",
     `Data is current through games on ${freshness.dataThroughLabel}.`,
     "",
-    "Choose exactly 3 players from the candidate list below who are best for a timely social post today.",
-    "Prioritize players who feel timely because of a feat, hot start, cold start, notable team context, or interesting overreaction potential.",
+    "Choose exactly 3 players from the news-first candidate list below who are best for a timely social post today.",
+    "Prioritize players whose news hook and McFARLAND angle work together; do not reward fame or big-market volume by itself.",
     "Recommend exactly 1 of the 3 as the best post today and explain why it is better than the others.",
     "Then draft 2 X posts and 2 Bluesky posts for the recommended player.",
     "Use the provided share_url in every draft.",
@@ -449,6 +651,8 @@ function buildFallbackResponse(candidates: SocialCandidate[]): SocialSuggestionR
 }
 
 export async function generateSocialSuggestions(baseUrl: string): Promise<SocialSuggestionResponse> {
+  const newsDrivenCandidates = await fetchNewsDrivenCandidatePool(baseUrl);
+
   const hitterCandidates = listPlayers("hitter")
     .map((player) => buildHitterCandidate(player as HitterRecord, baseUrl))
     .sort((a, b) => b.score - a.score)
@@ -459,14 +663,17 @@ export async function generateSocialSuggestions(baseUrl: string): Promise<Social
     .sort((a, b) => b.score - a.score)
     .slice(0, 8);
 
-  const candidatePool = [...hitterCandidates, ...pitcherCandidates]
+  const statCandidates = [...hitterCandidates, ...pitcherCandidates]
     .sort((a, b) => b.score - a.score)
     .slice(0, 10);
+  const candidatePool = newsDrivenCandidates.length > 0
+    ? supplementCandidatePool(newsDrivenCandidates, statCandidates)
+    : statCandidates;
 
   const enriched = await Promise.all(
     candidatePool.map(async (candidate) => ({
       ...candidate,
-      news: await fetchPlayerNews(candidate.playerName),
+      news: candidate.news.length > 0 ? candidate.news : await fetchPlayerNews(candidate.playerName),
     }))
   );
 
@@ -524,7 +731,36 @@ export async function generateSocialSuggestions(baseUrl: string): Promise<Social
   };
 }
 
-export function getTrendingQuickLinks(baseUrl: string): TrendingQuickLinksResponse {
+function toTrendPlayer(candidate: SocialCandidate): { id: string; name: string; type: PlayerType; mlbamid?: string | null } {
+  return {
+    id: candidate.playerId,
+    name: candidate.playerName,
+    type: candidate.playerType,
+    mlbamid: candidate.mlbamid ?? null,
+  };
+}
+
+async function getDailyNewsworthyQuickLinks(baseUrl: string): Promise<{ id: string; name: string; type: PlayerType; mlbamid?: string | null }[]> {
+  const { dataThroughDate } = getDataFreshness();
+  if (newsworthyQuickLinkCache?.dataThroughDate === dataThroughDate) {
+    return newsworthyQuickLinkCache.players;
+  }
+
+  const players = (await fetchNewsDrivenCandidatePool(baseUrl))
+    .slice(0, 3)
+    .map(toTrendPlayer);
+
+  newsworthyQuickLinkCache = {
+    dataThroughDate,
+    players,
+  };
+
+  return players;
+}
+
+export async function getTrendingQuickLinks(baseUrl: string): Promise<TrendingQuickLinksResponse> {
+  const newsworthy = await getDailyNewsworthyQuickLinks(baseUrl);
+
   const hitters = topTrendingCandidates("hitter", baseUrl).map((candidate) => ({
     id: candidate.playerId,
     name: candidate.playerName,
@@ -553,7 +789,16 @@ export function getTrendingQuickLinks(baseUrl: string): TrendingQuickLinksRespon
 
   return {
     generatedAt: new Date().toISOString(),
+    newsworthy,
     hitters: { trending: hitters, breakouts: hitterBreakouts },
     pitchers: { trending: pitchers, breakouts: pitcherBreakouts },
   };
+}
+
+export function __clearNewsworthyQuickLinkCacheForTests(): void {
+  newsworthyQuickLinkCache = null;
+}
+
+export function __setNewsDrivenCandidatePoolFetcherForTests(fetcher: NewsDrivenCandidatePoolFetcher | null): void {
+  newsDrivenCandidatePoolFetcher = fetcher;
 }

--- a/server/test/routes.test.ts
+++ b/server/test/routes.test.ts
@@ -644,6 +644,7 @@ describe("McFARLAND API", () => {
     const response = await request(app).get("/api/trending");
 
     expect(response.status).toBe(200);
+    expect(response.body.newsworthy).toBeInstanceOf(Array);
     expect(response.body.hitters.trending).toHaveLength(3);
     expect(response.body.hitters.breakouts).toHaveLength(3);
     expect(response.body.pitchers.trending).toHaveLength(3);

--- a/server/test/socialAssistant.test.ts
+++ b/server/test/socialAssistant.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { __setDataFreshnessForTests, getDataFreshness } from "../src/dataStore.js";
+import {
+  __clearNewsworthyQuickLinkCacheForTests,
+  __setNewsDrivenCandidatePoolFetcherForTests,
+  buildNewsDrivenCandidates,
+  getTrendingQuickLinks,
+} from "../src/socialAssistant.js";
+
+const originalFreshness = getDataFreshness();
+
+describe("social assistant news discovery", () => {
+  afterEach(() => {
+    __clearNewsworthyQuickLinkCacheForTests();
+    __setNewsDrivenCandidatePoolFetcherForTests(null);
+    __setDataFreshnessForTests(originalFreshness);
+  });
+
+  const playerIndex = [
+    {
+      playerId: "1",
+      playerType: "hitter",
+      playerName: "Aaron Judge",
+      score: 3,
+      whyNow: "Aaron Judge stands out because wOBA +.050 vs weighted baseline over 120 PA.",
+      statSnapshot: "120 PA · wOBA +.050",
+      shareUrl: "https://example.test/share?playerId=1",
+      news: [],
+    },
+    {
+      playerId: "2",
+      playerType: "pitcher",
+      playerName: "Tarik Skubal",
+      score: 4,
+      whyNow: "Tarik Skubal stands out because xERA -0.55 vs weighted baseline over 150 TBF.",
+      statSnapshot: "150 TBF · xERA -0.55",
+      shareUrl: "https://example.test/share?playerId=2",
+      news: [],
+    },
+  ] as const;
+
+  it("matches news headlines to McFARLAND players before scoring candidates", () => {
+    const candidates = buildNewsDrivenCandidates(
+      [
+        {
+          query: "MLB hot streak player",
+          title: "Aaron Judge keeps powering Yankees hot streak",
+          link: "https://mlb.example/judge",
+          source: "MLB.com",
+          publishedAt: new Date().toUTCString(),
+        },
+        {
+          query: "MLB strikeouts pitcher",
+          title: "Tarik Skubal piles up strikeouts again",
+          link: "https://detroit.example/skubal",
+          source: "Detroit News",
+          publishedAt: new Date().toUTCString(),
+        },
+      ],
+      [...playerIndex]
+    );
+
+    expect(candidates.map((candidate) => candidate.playerName)).toEqual(["Tarik Skubal", "Aaron Judge"]);
+    expect(candidates[0].news).toHaveLength(1);
+    expect(candidates[0].whyNow).toContain("today's MLB news cycle");
+    expect(candidates[0].whyNow).toContain("McFARLAND adds this angle");
+  });
+
+  it("deduplicates same-source mentions for the same player", () => {
+    const candidates = buildNewsDrivenCandidates(
+      [
+        {
+          query: "MLB hot streak player",
+          title: "Aaron Judge powers another hot streak",
+          link: "https://mlb.example/judge-1",
+          source: "MLB.com",
+          publishedAt: new Date().toUTCString(),
+        },
+        {
+          query: "MLB homer",
+          title: "Aaron Judge homer keeps Yankees rolling",
+          link: "https://mlb.example/judge-2",
+          source: "MLB.com",
+          publishedAt: new Date().toUTCString(),
+        },
+      ],
+      [...playerIndex]
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].playerName).toBe("Aaron Judge");
+    expect(candidates[0].news).toHaveLength(1);
+  });
+
+  it("caches newsworthy quick links for the current data day", async () => {
+    __setDataFreshnessForTests({ dataThroughDate: "2026-05-04", dataThroughLabel: "May 4" });
+    const fetcher = vi.fn(async () => [
+      {
+        playerId: "1",
+        playerType: "hitter" as const,
+        playerName: "Aaron Judge",
+        score: 10,
+        whyNow: "Aaron Judge is in the news.",
+        statSnapshot: "120 PA · wOBA +.050",
+        shareUrl: "https://example.test/share?playerId=1",
+        news: [],
+      },
+    ]);
+    __setNewsDrivenCandidatePoolFetcherForTests(fetcher);
+
+    const first = await getTrendingQuickLinks("https://example.test");
+    const second = await getTrendingQuickLinks("https://example.test");
+
+    expect(first.newsworthy).toEqual([{ id: "1", name: "Aaron Judge", type: "hitter", mlbamid: null }]);
+    expect(second.newsworthy).toEqual(first.newsworthy);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("refreshes newsworthy quick links when data day changes", async () => {
+    const fetcher = vi
+      .fn()
+      .mockResolvedValueOnce([
+        {
+          playerId: "1",
+          playerType: "hitter" as const,
+          playerName: "Aaron Judge",
+          score: 10,
+          whyNow: "Aaron Judge is in the news.",
+          statSnapshot: "120 PA · wOBA +.050",
+          shareUrl: "https://example.test/share?playerId=1",
+          news: [],
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          playerId: "2",
+          playerType: "pitcher" as const,
+          playerName: "Tarik Skubal",
+          score: 10,
+          whyNow: "Tarik Skubal is in the news.",
+          statSnapshot: "150 TBF · xERA -.055",
+          shareUrl: "https://example.test/share?playerId=2",
+          news: [],
+        },
+      ]);
+    __setNewsDrivenCandidatePoolFetcherForTests(fetcher);
+
+    __setDataFreshnessForTests({ dataThroughDate: "2026-05-04", dataThroughLabel: "May 4" });
+    const first = await getTrendingQuickLinks("https://example.test");
+
+    __setDataFreshnessForTests({ dataThroughDate: "2026-05-05", dataThroughLabel: "May 5" });
+    const second = await getTrendingQuickLinks("https://example.test");
+
+    expect(first.newsworthy[0]).toMatchObject({ id: "1", name: "Aaron Judge" });
+    expect(second.newsworthy[0]).toMatchObject({ id: "2", name: "Tarik Skubal" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Customer value
- Adds an "In the News" quick-link row so users can jump straight into analysis for players already in the MLB conversation.
- Makes the social assistant start with newsworthy players first, then layer in McFARLAND stats for the angle.
- Keeps the news chips stable for the data day so users see a consistent daily set and the server avoids repeated RSS work.

## Implementation notes
- Adds broad Google News RSS discovery queries for event-style player news, then matches headlines back to local McFARLAND players.
- Scores news-first candidates using freshness, event specificity, source diversity, and McFARLAND signal, with same-source dedupe.
- Adds a daily in-memory cache for the top 3 newsworthy quick links keyed by dataThroughDate.
- Extends /api/trending with a top-level newsworthy list and renders it under Analyze Again on the single-player page.
- Lets newsworthy chips switch between hitter and pitcher views when selected.

## Test coverage
- npm run test --workspace server
- npm run build