### PR TITLE
Simplify quick links so users reach analysis faster

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,3 +14,5 @@ git checkout -b <new-branch-name>
 All pull requests must be real, non-draft PRs.
 
 PR titles and descriptions should be customer-value focused. Lead with what the user or customer gets from the change, then include implementation notes and test coverage as supporting detail.
+
+Before creating a PR, review the full branch diff and make sure client and server tests still match the changed behavior. A branch may go through several implementation iterations, so tests do not need to be updated after every prompt, but they must be updated before PR creation. If tests need changes, make those changes and commit them before opening the PR. The PR description should include the relevant test commands that were run, or clearly state any test that could not be run.

--- a/client/src/components/WeeklyTrendsSection.tsx
+++ b/client/src/components/WeeklyTrendsSection.tsx
@@ -22,22 +22,30 @@ type Props = {
   embedded?: boolean;
 };
 
+type QuickIdeaId = "breakouts" | "trends" | "out-of-character";
+
 function TrendGroup({
   title,
   emoji,
   players,
   onSelectPlayer,
+  getChipPrefix,
+  hideLeadIn = false,
 }: {
   title: string;
   emoji: string;
   players: TrendPlayer[];
   onSelectPlayer: Props["onSelectPlayer"];
+  getChipPrefix?: (player: TrendPlayer) => string | undefined;
+  hideLeadIn?: boolean;
 }) {
   return (
     <section className={styles.row} aria-label={title}>
-      <p className={styles.rowLeadIn}>
-        <span aria-hidden="true">{emoji}</span> {title}:
-      </p>
+      {!hideLeadIn && (
+        <p className={styles.rowLeadIn}>
+          <span aria-hidden="true">{emoji}</span> {title}:
+        </p>
+      )}
       <div className={styles.chipList}>
         {players.map((player) => (
           <button
@@ -56,6 +64,9 @@ function TrendGroup({
               mlbamid={player.mlbamid}
               size={20}
             />
+            {getChipPrefix?.(player) && (
+              <span className={styles.chipPrefix}>{getChipPrefix(player)}</span>
+            )}
             <span>{player.name}</span>
           </button>
         ))}
@@ -109,6 +120,7 @@ function RecentAnalysesGroup({
 
 export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedded = false }: Props) {
   const [collapsedOnMobile, setCollapsedOnMobile] = useState(false);
+  const [activeIdea, setActiveIdea] = useState<QuickIdeaId>("breakouts");
   const [recentAnalyses, setRecentAnalyses] = useState<RecentAnalysisEntry[]>([]);
 
   useEffect(() => {
@@ -159,6 +171,31 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
   const newsworthyPlayers = trendingQuery.data?.newsworthy ?? [];
   const onFirePlayers = trendBucket?.risers ?? [];
   const iceColdPlayers = trendBucket?.fallers ?? [];
+  const trendPlayers = [...onFirePlayers, ...iceColdPlayers];
+  const quickIdeaGroups = [
+    {
+      id: "breakouts" as const,
+      label: "Breakouts",
+      emoji: "🚀",
+      players: breakoutPlayers,
+    },
+    {
+      id: "trends" as const,
+      label: "Trends",
+      emoji: "📈",
+      players: trendPlayers,
+      getChipPrefix: (player: TrendPlayer) =>
+        onFirePlayers.some((entry) => entry.id === player.id) ? "🔥" : "🥶",
+    },
+    {
+      id: "out-of-character" as const,
+      label: "Out of Character",
+      emoji: "👀",
+      players: trendingPlayers,
+    },
+  ].filter((group) => group.players.length > 0);
+  const selectedIdeaGroup =
+    quickIdeaGroups.find((group) => group.id === activeIdea) ?? quickIdeaGroups[0];
 
   return (
     <section className={clsx(styles.wrapper, embedded && styles.embedded)} aria-label="Quick links">
@@ -177,43 +214,41 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
         {(trendsQuery.isError || trendingQuery.isError) && <p className={styles.subhead}>Unable to load quick links right now.</p>}
         {!trendingQuery.isLoading && !trendingQuery.isError && newsworthyPlayers.length > 0 && (
           <TrendGroup
-            title="In the News"
+            title="Start here"
             emoji="📰"
             players={newsworthyPlayers}
             onSelectPlayer={onSelectPlayer}
           />
         )}
-        {!trendingQuery.isLoading && !trendingQuery.isError && breakoutPlayers.length > 0 && (
-          <TrendGroup
-            title="Breakouts"
-            emoji="🚀"
-            players={breakoutPlayers}
-            onSelectPlayer={onSelectPlayer}
-          />
-        )}
-        {!trendingQuery.isLoading && !trendingQuery.isError && trendingPlayers.length > 0 && (
-          <TrendGroup
-            title="Out of Character"
-            emoji="👀"
-            players={trendingPlayers}
-            onSelectPlayer={onSelectPlayer}
-          />
-        )}
-        {!trendsQuery.isLoading && !trendsQuery.isError && (
-          <>
+        {!trendsQuery.isLoading && !trendsQuery.isError && !trendingQuery.isLoading && !trendingQuery.isError && selectedIdeaGroup && (
+          <section className={styles.ideaPanel} aria-label="More ideas">
+            <div className={styles.ideaHeader}>
+              <p className={styles.rowLeadIn}>More ideas:</p>
+              <div className={styles.ideaTabs} role="tablist" aria-label="Choose quick-link category">
+                {quickIdeaGroups.map((group) => (
+                  <button
+                    key={group.id}
+                    type="button"
+                    className={clsx(styles.ideaTab, selectedIdeaGroup.id === group.id && styles.ideaTabActive)}
+                    onClick={() => setActiveIdea(group.id)}
+                    role="tab"
+                    aria-selected={selectedIdeaGroup.id === group.id}
+                  >
+                    <span aria-hidden="true">{group.emoji}</span>
+                    <span>{group.label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
             <TrendGroup
-              title="On Fire"
-              emoji="🔥"
-              players={onFirePlayers}
+              title={selectedIdeaGroup.label}
+              emoji={selectedIdeaGroup.emoji}
+              players={selectedIdeaGroup.players}
               onSelectPlayer={onSelectPlayer}
+              getChipPrefix={selectedIdeaGroup.getChipPrefix}
+              hideLeadIn
             />
-            <TrendGroup
-              title="Ice Cold"
-              emoji="🥶"
-              players={iceColdPlayers}
-              onSelectPlayer={onSelectPlayer}
-            />
-          </>
+          </section>
         )}
       </div>
     </section>

--- a/client/src/styles/WeeklyTrendsSection.module.css
+++ b/client/src/styles/WeeklyTrendsSection.module.css
@@ -81,6 +81,12 @@
   gap: 0.35rem;
 }
 
+.chipPrefix {
+  color: #475569;
+  font-size: 0.74rem;
+  line-height: 1;
+}
+
 .chipButton {
   border: 1px solid rgba(148, 163, 184, 0.2);
   border-radius: 999px;
@@ -96,6 +102,63 @@
   text-align: left;
   cursor: pointer;
   transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.15s ease;
+}
+
+.ideaPanel {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.ideaHeader {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.ideaTabs {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.55rem;
+  background: rgba(241, 245, 249, 0.86);
+  padding: 0.12rem;
+}
+
+.ideaTab {
+  border: 0;
+  border-radius: 0.38rem;
+  background: transparent;
+  color: #475569;
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.72rem;
+  font-weight: 800;
+  line-height: 1;
+  padding: 0.36rem 0.58rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  transition: background 0.16s ease, color 0.16s ease, box-shadow 0.16s ease;
+}
+
+.ideaTab:hover,
+.ideaTab:focus-visible {
+  background: rgba(255, 255, 255, 0.7);
+  color: #1d4ed8;
+  outline: none;
+}
+
+.ideaTabActive {
+  background: #fff;
+  color: #0f172a;
+  box-shadow: 0 1px 3px rgba(15, 23, 42, 0.16);
+}
+
+.ideaTabActive:hover,
+.ideaTabActive:focus-visible {
+  color: #0f172a;
 }
 
 .chipButton:hover,

--- a/tests/e2e/tests/app.spec.ts
+++ b/tests/e2e/tests/app.spec.ts
@@ -62,21 +62,22 @@ test.describe("McFARLAND core experience", () => {
     await page.reload();
     await expect(singleSearchInput(page)).toBeVisible();
 
-    const onFireRow = page.locator("section[aria-label='On Fire']");
-    const iceColdRow = page.locator("section[aria-label='Ice Cold']");
+    const moreIdeasPanel = page.locator("section[aria-label='More ideas']");
     const analyzeAgainRow = page.locator("section[aria-label='Analyze again']");
     const analysisPanel = page.locator("section[aria-label='AI analysis']");
     const analysisHeadshot = analysisPanel.locator("img[alt$='headshot']").first();
 
-    await expect(onFireRow).toBeVisible();
-    await expect(iceColdRow).toBeVisible();
+    await expect(moreIdeasPanel).toBeVisible();
+    await moreIdeasPanel.getByRole("tab", { name: /Trends/ }).click();
+    const trendsRow = page.locator("section[aria-label='Trends']");
+    await expect(trendsRow).toBeVisible();
 
-    const onFireButton = onFireRow.locator("button").first();
-    const firstPlayerName = ((await onFireButton.textContent()) ?? "").trim();
+    const firstTrendButton = trendsRow.locator("button").first();
+    const firstPlayerName = ((await firstTrendButton.textContent()) ?? "").replace(/[🔥🥶]/g, "").trim();
     expect(firstPlayerName).not.toBe("");
 
     const firstAnalyzeFinished = waitForPostRequestFinished(page, "/api/analyze");
-    await onFireButton.click();
+    await firstTrendButton.click();
     await firstAnalyzeFinished;
     await expectAnalysisReady(page);
 
@@ -86,9 +87,9 @@ test.describe("McFARLAND core experience", () => {
     const firstHeadshotSrc = await analysisHeadshot.getAttribute("src");
     expect(firstHeadshotSrc).toBeTruthy();
 
-    const onFireButtons = onFireRow.locator("button");
-    const secondCandidateButton = (await onFireButtons.count()) > 1 ? onFireButtons.nth(1) : iceColdRow.locator("button").first();
-    const secondPlayerName = ((await secondCandidateButton.textContent()) ?? "").trim();
+    const trendButtons = trendsRow.locator("button");
+    const secondCandidateButton = trendButtons.nth(1);
+    const secondPlayerName = ((await secondCandidateButton.textContent()) ?? "").replace(/[🔥🥶]/g, "").trim();
     expect(secondPlayerName).not.toBe("");
     expect(secondPlayerName).not.toBe(firstPlayerName);
 
@@ -150,12 +151,13 @@ test.describe("McFARLAND core experience", () => {
     await page.goto("/");
     await expect(singleSearchInput(page)).toBeVisible();
 
-    const onFireRow = page.locator("section[aria-label='On Fire']");
-    const iceColdRow = page.locator("section[aria-label='Ice Cold']");
-    await expect(onFireRow).toBeVisible();
-    await expect(iceColdRow).toBeVisible();
+    const moreIdeasPanel = page.locator("section[aria-label='More ideas']");
+    await expect(moreIdeasPanel).toBeVisible();
+    await moreIdeasPanel.getByRole("tab", { name: /Breakouts/ }).click();
+    const breakoutsRow = page.locator("section[aria-label='Breakouts']");
+    await expect(breakoutsRow).toBeVisible();
 
-    const firstQuickLink = onFireRow.locator("button").first();
+    const firstQuickLink = breakoutsRow.locator("button").first();
     const clickedPlayerName = (await firstQuickLink.textContent())?.trim() ?? "";
     expect(clickedPlayerName).not.toBe("");
 
@@ -169,8 +171,8 @@ test.describe("McFARLAND core experience", () => {
     expect(singleAnalyzeRequests.at(-1)?.playerId).not.toBe("");
 
     await page.getByRole("tab", { name: "Compare Players" }).click();
-    await expect(page.locator("section[aria-label='On Fire']")).toHaveCount(0);
-    await expect(page.locator("section[aria-label='Ice Cold']")).toHaveCount(0);
+    await expect(page.locator("section[aria-label='More ideas']")).toHaveCount(0);
+    await expect(page.locator("section[aria-label='Breakouts']")).toHaveCount(0);
   });
 
   test("single analysis, vibe switch, compare three players, share link", async ({ page, context }) => {


### PR DESCRIPTION
## Customer value
- Reduces quick-link clutter so users can get from page load to a useful analysis faster.
- Keeps the strongest daily recommendation visible as "Start here" while moving secondary discovery paths behind a compact "More ideas" selector.
- Makes the selector visually distinct from player chips so users can tell navigation controls from analysis targets.

## Implementation notes
- Combines the old On Fire and Ice Cold rows into one Trends category with inline heat/cold markers.
- Keeps Breakouts and Out of Character available behind the More ideas segmented control.
- Removes the duplicated selected-category header below the selector and moves category emoji into the tabs.
- Updates e2e expectations for the new quick-link structure.
- Updates AGENTS.md so test updates are part of the pre-PR checklist going forward.

## Test coverage
- npm run test --workspace client
- npm run test --workspace server
- npm run build
- Not run: npm run test:e2e, because it requires starting the app server and the current instruction is not to run the server.