### PR TITLE
Rename news quick links to In the News

### DIFF
--- a/client/src/components/WeeklyTrendsSection.tsx
+++ b/client/src/components/WeeklyTrendsSection.tsx
@@ -223,7 +223,9 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
         {!trendsQuery.isLoading && !trendsQuery.isError && !trendingQuery.isLoading && !trendingQuery.isError && selectedIdeaGroup && (
           <section className={styles.ideaPanel} aria-label="More ideas">
             <div className={styles.ideaHeader}>
-              <p className={styles.rowLeadIn}>More Ideas:</p>
+              <p className={styles.rowLeadIn}>
+                <span aria-hidden="true">＋</span> More Ideas:
+              </p>
               <div className={styles.ideaTabs} role="tablist" aria-label="Choose quick-link category">
                 {quickIdeaGroups.map((group) => (
                   <button

--- a/client/src/components/WeeklyTrendsSection.tsx
+++ b/client/src/components/WeeklyTrendsSection.tsx
@@ -223,7 +223,7 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
         {!trendsQuery.isLoading && !trendsQuery.isError && !trendingQuery.isLoading && !trendingQuery.isError && selectedIdeaGroup && (
           <section className={styles.ideaPanel} aria-label="More ideas">
             <div className={styles.ideaHeader}>
-              <p className={styles.rowLeadIn}>More ideas:</p>
+              <p className={styles.rowLeadIn}>More Ideas:</p>
               <div className={styles.ideaTabs} role="tablist" aria-label="Choose quick-link category">
                 {quickIdeaGroups.map((group) => (
                   <button

--- a/client/src/components/WeeklyTrendsSection.tsx
+++ b/client/src/components/WeeklyTrendsSection.tsx
@@ -214,7 +214,7 @@ export default function WeeklyTrendsSection({ playerType, onSelectPlayer, embedd
         {(trendsQuery.isError || trendingQuery.isError) && <p className={styles.subhead}>Unable to load quick links right now.</p>}
         {!trendingQuery.isLoading && !trendingQuery.isError && newsworthyPlayers.length > 0 && (
           <TrendGroup
-            title="Start here"
+            title="In the News"
             emoji="📰"
             players={newsworthyPlayers}
             onSelectPlayer={onSelectPlayer}


### PR DESCRIPTION
## Customer value
- Makes the primary quick-link row clearer by labeling news-driven player suggestions as "In the News" instead of the vague "Start here".

## Implementation notes
- Updates the WeeklyTrendsSection row title for newsworthy players.
- No test updates were needed because existing tests do not assert this label text.

## Test coverage
- npm run test --workspace client
- npm run test --workspace server
- npm run build
- Not run: npm run test:e2e, because it requires starting the app server and the current instruction is not to run the server.