### PR TITLE
Remove visible FanGraphs references

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,4 +157,4 @@ npm run build
 
 ## License
 
-Educational and personal use only. Respect FanGraphs' and MLB's data/image terms.
+Educational and personal use only. Respect applicable baseball data and image terms.

--- a/client/src/pages/AboutPage.tsx
+++ b/client/src/pages/AboutPage.tsx
@@ -26,7 +26,7 @@ const ABOUT_SECTIONS = [
     items: [
       "Advanced stats shouldn't require a graduate seminar. McFARLAND translates them into friendly stories you can drop in chats or fantasy forums.",
       "Fresh info every morning in-season, right after last night's games, so you're never flexing stale numbers.",
-      "Named for former Orioles swiss-army reliever T.J. McFarland, our mascot for adaptability. <a href=\"https://www.fangraphs.com/players/tj-mcfarland/3237/stats?position=P\" target=\"_blank\" rel=\"noreferrer\">Give the man his due</a>.",
+      "Named for former Orioles swiss-army reliever T.J. McFarland, our mascot for adaptability.",
     ],
   },
 ];


### PR DESCRIPTION
## What users get
The public site and README no longer call out FanGraphs by name in visible copy, keeping source language more general while preserving the existing product experience.

## Implementation notes
- Removed the FanGraphs link from the T.J. McFarland mascot blurb on the About page.
- Generalized the README license note to applicable baseball data and image terms.

## Verification
- npm run test --workspace client
- npm run test --workspace server
- npm run build