### PR TITLE
Make MLB data terms visible

### DIFF
--- a/client/src/pages/AboutPage.tsx
+++ b/client/src/pages/AboutPage.tsx
@@ -114,6 +114,14 @@ function AboutPage() {
           </a>
         </p>
       </section>
+
+      <p className={styles.attribution}>
+        MLB data © MLB Advanced Media, L.P. Use of MLB data is subject to{" "}
+        <a href="http://gdx.mlb.com/components/copyright.txt" target="_blank" rel="noreferrer">
+          MLB&apos;s terms
+        </a>
+        .
+      </p>
     </article>
   );
 }

--- a/client/src/styles/AboutPage.module.css
+++ b/client/src/styles/AboutPage.module.css
@@ -84,3 +84,20 @@
   color: #475569;
   font-weight: 500;
 }
+
+.attribution {
+  margin: -0.25rem 0 0;
+  color: #64748b;
+  font-size: 0.82rem;
+  line-height: 1.45;
+}
+
+.attribution a {
+  color: #1d4ed8;
+  text-decoration: none;
+}
+
+.attribution a:hover,
+.attribution a:focus-visible {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- Add MLB data attribution at the bottom of the About page.
- Link directly to MLB's published data terms from the attribution copy.

## Customer impact
- Makes the MLB data usage terms visible to users now that the app consumes MLB Stats API data.
- Keeps the attribution unobtrusive while still discoverable on the About page.

## Validation
- npm run test --workspace client
- npm run build