### PR TITLE
Single-player analysis shows key stat signals at a glance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useSearchParams } from "react-router-dom";
 import SinglePlayerPage from "./pages/SinglePlayerPage";
 import ComparePage from "./pages/ComparePage";
@@ -7,7 +8,7 @@ import AboutPage from "./pages/AboutPage";
 import SocialAssistantPage from "./pages/SocialAssistantPage";
 import { VibeProvider, useVibe } from "./contexts/VibeContext";
 import styles from "./styles/App.module.css";
-import { registerSession } from "./api";
+import { fetchDataFreshness, registerSession } from "./api";
 import type { PlayerType } from "./types";
 
 type ExperienceMode = "single" | "compare" | "fantasy";
@@ -47,6 +48,10 @@ function AppShell() {
   const [searchParams, setSearchParams] = useSearchParams();
   const { mode: vibeMode, setMode: setVibeMode, vibes, defaultMode } = useVibe();
   const lastUrlVibeRef = useRef<string | null>(searchParams.get(VIBE_PARAM));
+  const freshnessQuery = useQuery({
+    queryKey: ["data-freshness"],
+    queryFn: fetchDataFreshness,
+  });
 
   const rawMode = searchParams.get(EXPERIENCE_PARAM);
   const urlMode: ExperienceMode = rawMode === "compare" || rawMode === "fantasy" ? rawMode : "single";
@@ -246,6 +251,11 @@ function AppShell() {
       </main>
 
       <footer className={styles.footer}>
+        {freshnessQuery.data && (
+          <p className={styles.footerTagline}>
+            All stats are through games on {freshnessQuery.data.dataThroughLabel}.
+          </p>
+        )}
         <button
           type="button"
           className={styles.linkButton}

--- a/client/src/components/AnalysisPanel.tsx
+++ b/client/src/components/AnalysisPanel.tsx
@@ -2,10 +2,16 @@ import ReactMarkdown from "react-markdown";
 import type { ReactNode } from "react";
 import styles from "../styles/AnalysisPanel.module.css";
 
+export type QuickStatSignal = {
+  label: string;
+  tone?: "positive" | "negative" | "neutral";
+};
+
 interface Props {
   header?: ReactNode;
   quickInsight?: string;
   quickStatsLine?: string;
+  quickStatSignals?: QuickStatSignal[];
   onAnalyze?: () => void;
   actionLabel?: string;
   nextSteps?: ReactNode;
@@ -21,6 +27,7 @@ function AnalysisPanel({
   header,
   quickInsight,
   quickStatsLine,
+  quickStatSignals = [],
   onAnalyze,
   actionLabel,
   nextSteps,
@@ -33,17 +40,12 @@ function AnalysisPanel({
 }: Props) {
   const showAnalysisBody = Boolean(isAnalyzing || analysis);
   const normalizedHeadline = headline?.replace(/\s+/g, " ").trim();
+  const showContext = Boolean(quickStatsLine || quickStatSignals.length > 0);
 
   return (
     <section className={styles.panel} aria-label="AI analysis">
       {header}
-      {quickInsight && (
-        <div className={styles.quickInsight}>
-          <h3>Quick insight</h3>
-          <p>{quickInsight}</p>
-          {quickStatsLine && <p className={styles.freshness}>{quickStatsLine}</p>}
-        </div>
-      )}
+      {!showAnalysisBody && quickInsight && <p className={styles.preAnalysisHint}>{quickInsight}</p>}
 
       {onAnalyze && (
         <button
@@ -64,6 +66,23 @@ function AnalysisPanel({
             analysis && (
               <>
                 {normalizedHeadline && <h3 className={styles.headline}>{normalizedHeadline}</h3>}
+                {showContext && (
+                  <div className={styles.analysisContext}>
+                    {quickStatsLine && <p className={styles.freshness}>{quickStatsLine}</p>}
+                    {quickStatSignals.length > 0 && (
+                      <div className={styles.signalChips} aria-label="Key signals">
+                        {quickStatSignals.map((signal) => (
+                          <span
+                            key={signal.label}
+                            className={`${styles.signalChip} ${styles[signal.tone ?? "neutral"]}`}
+                          >
+                            {signal.label}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                )}
                 <ReactMarkdown>{analysis}</ReactMarkdown>
               </>
             )

--- a/client/src/components/__tests__/AnalysisPanel.test.tsx
+++ b/client/src/components/__tests__/AnalysisPanel.test.tsx
@@ -1,0 +1,27 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import AnalysisPanel from "../AnalysisPanel";
+
+describe("AnalysisPanel", () => {
+  it("renders the headline as the takeaway with stat signals as context", () => {
+    render(
+      <AnalysisPanel
+        quickInsight="Improving with a few real skill gains."
+        quickStatSignals={[
+          { label: "xwOBA +.041", tone: "positive" },
+          { label: "Barrel% +3.2", tone: "positive" },
+          { label: "BABIP +.062", tone: "neutral" },
+        ]}
+        headline="The skills are moving in the right direction"
+        analysis="The improved contact quality makes the start more interesting."
+      />
+    );
+
+    expect(screen.queryByText("Quick insight")).not.toBeInTheDocument();
+    expect(screen.getByRole("heading", { name: "The skills are moving in the right direction" })).toBeInTheDocument();
+    expect(screen.getByLabelText("Key signals")).toBeInTheDocument();
+    expect(screen.getByText("xwOBA +.041")).toBeInTheDocument();
+    expect(screen.getByText("Barrel% +3.2")).toBeInTheDocument();
+    expect(screen.getByText("BABIP +.062")).toBeInTheDocument();
+  });
+});

--- a/client/src/pages/SinglePlayerPage.tsx
+++ b/client/src/pages/SinglePlayerPage.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import PlayerPicker from "../components/PlayerPicker";
 import AnalysisPanel from "../components/AnalysisPanel";
+import type { QuickStatSignal } from "../components/AnalysisPanel";
 import VibeSelector from "../components/VibeSelector";
 import PlayerHeadshot from "../components/PlayerHeadshot";
 import WeeklyTrendsSection from "../components/WeeklyTrendsSection";
@@ -9,7 +10,6 @@ import panelStyles from "../styles/AnalysisPanel.module.css";
 import { useVibe } from "../contexts/VibeContext";
 import {
   analyzePlayer,
-  fetchDataFreshness,
   fetchPlayerDetail,
   fetchPlayers,
   logShareAnalyticsEvent,
@@ -57,22 +57,121 @@ function formatAge(value: number | null | undefined): string | undefined {
   return String(Math.round(value));
 }
 
-function buildQuickStatsLine(
+function isFiniteNumber(value: number | null | undefined): value is number {
+  return value !== null && value !== undefined && Number.isFinite(value);
+}
+
+function formatSignedValue(value: number, digits: number): string {
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${Number(value).toFixed(digits)}`.replace(/^([+-]?)0\./, "$1.");
+}
+
+type SignalCandidate = QuickStatSignal & {
+  score: number;
+};
+
+function buildSignal(
+  label: string,
+  value: number | null | undefined,
+  digits: number,
+  scoreMultiplier: number,
+  goodDirection: 1 | -1 | 0 = 1
+): SignalCandidate | null {
+  if (!isFiniteNumber(value) || Math.abs(value) < 0.0005) {
+    return null;
+  }
+
+  const tone =
+    goodDirection === 0
+      ? "neutral"
+      : value * goodDirection > 0
+        ? "positive"
+        : "negative";
+
+  return {
+    label: `${label} ${formatSignedValue(value, digits)}`,
+    score: Math.abs(value) * scoreMultiplier,
+    tone,
+  };
+}
+
+function formatCurrentValue(value: number, digits: number, suffix = ""): string {
+  return `${Number(value).toFixed(digits)}${suffix}`.replace(/^(-?)0\./, "$1.");
+}
+
+function buildCurrentSignal(label: string, value: number | null | undefined, digits: number, suffix = ""): QuickStatSignal | null {
+  if (!isFiniteNumber(value)) {
+    return null;
+  }
+
+  return {
+    label: `${label} ${formatCurrentValue(value, digits, suffix)}`,
+    tone: "neutral",
+  };
+}
+
+function buildQuickStatSignals(player: HitterRecord | PitcherRecord, playerType: PlayerType): QuickStatSignal[] {
+  const signals =
+    playerType === "hitter"
+      ? [
+          buildSignal("xwOBA", (player as HitterRecord).xwOBA_diff, 3, 100),
+          buildSignal("wOBA", (player as HitterRecord).wOBA_diff, 3, 100),
+          buildSignal("Barrel%", (player as HitterRecord).Barrel_pct_diff, 1, 1),
+          buildSignal("K%", (player as HitterRecord).K_pct_diff, 1, 1, -1),
+          buildSignal("BB%", (player as HitterRecord).BB_pct_diff, 1, 1),
+          buildSignal("BABIP", (player as HitterRecord).BABIP_diff, 3, 100, 0),
+          buildSignal("xwOBA-wOBA", (player as HitterRecord).xwOBA_wOBA_gap_diff, 3, 100),
+        ]
+      : [
+          buildSignal("xERA", (player as PitcherRecord).xera_diff, 2, 1, -1),
+          buildSignal("ERA", (player as PitcherRecord).era_diff, 2, 1, -1),
+          buildSignal("K-BB%", (player as PitcherRecord).k_minus_bb_percent_diff, 1, 1),
+          buildSignal("CSW%", (player as PitcherRecord).csw_percent_diff, 1, 1),
+          buildSignal("Barrel%", (player as PitcherRecord).barrel_percent_diff, 1, 1, -1),
+          buildSignal("BABIP", (player as PitcherRecord).babip_diff, 3, 100, 0),
+          buildSignal("LOB%", (player as PitcherRecord).lob_percent_diff, 1, 1, 0),
+        ];
+
+  const diffSignals = signals
+    .filter((signal): signal is SignalCandidate => Boolean(signal))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, 3)
+    .map(({ label, tone }) => ({ label, tone }));
+
+  if (diffSignals.length > 0) {
+    return diffSignals;
+  }
+
+  const fallbackSignals =
+    playerType === "hitter"
+      ? [
+          buildCurrentSignal("xwOBA", (player as HitterRecord).xwOBA_cur, 3),
+          buildCurrentSignal("wOBA", (player as HitterRecord).wOBA_cur, 3),
+          buildCurrentSignal("Barrel%", (player as HitterRecord).Barrel_pct_cur, 1, "%"),
+        ]
+      : [
+          buildCurrentSignal("xERA", (player as PitcherRecord).xera_cur, 2),
+          buildCurrentSignal("K-BB%", (player as PitcherRecord).k_minus_bb_percent_cur, 1, "%"),
+          buildCurrentSignal("CSW%", (player as PitcherRecord).csw_percent_cur, 1, "%"),
+        ];
+
+  return fallbackSignals.filter((signal): signal is QuickStatSignal => Boolean(signal));
+}
+
+function buildPlayerMetaLine(
   player: HitterRecord | PitcherRecord,
   playerType: PlayerType,
-  dataThroughLabel?: string
+  ageLabel?: string
 ): string | undefined {
-  if (!dataThroughLabel) {
-    return undefined;
-  }
+  const prefix = ageLabel ? `Age ${ageLabel} · ` : "";
 
   if (playerType === "hitter") {
     const hitter = player as HitterRecord;
-    return `Through ${dataThroughLabel}: ${formatInteger(hitter.PA_cur)} PA · ${formatSlashStat(hitter.AVG_cur)}/${formatSlashStat(hitter.OBP_cur)}/${formatSlashStat(hitter.SLG_cur)}`;
+    return `${prefix}${formatSlashStat(hitter.AVG_cur)}/${formatSlashStat(hitter.OBP_cur)}/${formatSlashStat(hitter.SLG_cur)} in ${formatInteger(hitter.PA_cur)} PA`;
   }
 
   const pitcher = player as PitcherRecord;
-  return `Through ${dataThroughLabel}: ${formatInteger(pitcher.tbf)} TBF · ${formatEra(pitcher.era_cur)} ERA · ${formatInteger(pitcher.so)} SO · ${formatInteger(pitcher.bb)} BB`;
+  return `${prefix}${formatEra(pitcher.era_cur)} ERA, ${formatInteger(pitcher.so)} SO, ${formatInteger(pitcher.bb)} BB in ${formatInteger(pitcher.tbf)} TBF`;
 }
 
 function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateChange }: Props) {
@@ -108,11 +207,6 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
     enabled: Boolean(selectedId),
   });
 
-  const freshnessQuery = useQuery({
-    queryKey: ["data-freshness"],
-    queryFn: fetchDataFreshness,
-  });
-
   const lastAnalysisKeyRef = useRef<string | null>(null);
   const {
     mutate: runAnalysis,
@@ -135,11 +229,13 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
   const hasSelectedPlayer = Boolean(selectedId);
   const hasPlayerProfile = Boolean(detailQuery.data);
   const analysisReady = Boolean(analysisData?.analysis);
-  const quickStatsLine =
-    detailQuery.data && freshnessQuery.data
-      ? buildQuickStatsLine(detailQuery.data.player, playerType, freshnessQuery.data.dataThroughLabel)
-      : undefined;
+  const quickStatSignals = detailQuery.data
+    ? buildQuickStatSignals(detailQuery.data.player, playerType)
+    : [];
   const selectedPlayerAge = detailQuery.data ? formatAge(detailQuery.data.player.Age) : undefined;
+  const selectedPlayerMetaLine = detailQuery.data
+    ? buildPlayerMetaLine(detailQuery.data.player, playerType, selectedPlayerAge)
+    : undefined;
 
   useEffect(() => {
     if (!selectedId) {
@@ -298,13 +394,13 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
                       />
                       <div className={styles.playerMeta}>
                         <h2>{detailQuery.data.player.Name}</h2>
-                        {selectedPlayerAge && <p>Age {selectedPlayerAge}</p>}
+                        {selectedPlayerMetaLine && <p>{selectedPlayerMetaLine}</p>}
                       </div>
                     </div>
                   </header>
                 )}
                 quickInsight={detailQuery.data.quickInsight}
-                quickStatsLine={quickStatsLine}
+                quickStatSignals={quickStatSignals}
                 isAnalyzing={isAnalysisPending}
                 headline={analysisData?.headline}
                 analysis={analysisData?.analysis}

--- a/client/src/styles/AnalysisPanel.module.css
+++ b/client/src/styles/AnalysisPanel.module.css
@@ -11,20 +11,54 @@
   box-sizing: border-box;
 }
 
-.quickInsight h3 {
+.preAnalysisHint {
   margin: 0;
-  color: #1f2937;
-  font-size: 1.1rem;
-}
-
-.quickInsight p {
-  margin: 0.35rem 0 0;
   color: #475569;
   line-height: 1.6;
 }
 
 .freshness {
-  margin-top: 0.55rem;
+  margin: 0;
+}
+
+.signalChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0;
+}
+
+.signalChip {
+  display: inline-flex;
+  align-items: center;
+  min-height: 1.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.28);
+  padding: 0.25rem 0.65rem;
+  color: #334155;
+  background: #f8fafc;
+  font-size: 0.84rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+}
+
+.positive {
+  border-color: rgba(22, 163, 74, 0.22);
+  background: rgba(240, 253, 244, 0.96);
+  color: #166534;
+}
+
+.negative {
+  border-color: rgba(220, 38, 38, 0.22);
+  background: rgba(254, 242, 242, 0.96);
+  color: #991b1b;
+}
+
+.neutral {
+  border-color: rgba(37, 99, 235, 0.18);
+  background: rgba(239, 246, 255, 0.96);
+  color: #1e40af;
 }
 
 .button {
@@ -71,6 +105,9 @@
   text-wrap: wrap;
 }
 
+.analysisContext {
+  margin: -0.25rem 0 1rem;
+}
 
 .loading {
   margin: 0;

--- a/client/src/styles/SingleExperience.module.css
+++ b/client/src/styles/SingleExperience.module.css
@@ -36,8 +36,7 @@
 
 .analysisIdentity {
   margin: -0.1rem -0.1rem 0.2rem;
-  padding: 0 0 clamp(0.9rem, 2vw, 1.1rem);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 0;
 }
 
 .playerMeta h2 {


### PR DESCRIPTION
## What changes for users

Single-player analysis now surfaces the player snapshot and the most notable stat signals without crowding out the generated headline.

## Implementation notes

- Moves the player-specific stat summary into the headshot/name strip, e.g. `Age 28 · .280/.350/.510 in 180 PA`.
- Moves the constant data-through date to the app footer so it appears once globally.
- Shows key signal chips directly under the generated headline.
- Selects the strongest current-vs-baseline signals for hitters and pitchers, with current-skill fallbacks so the chip row is not empty.
- Removes the extra divider in the single-player analysis header area.
- Adds focused `AnalysisPanel` coverage for headline-plus-chip rendering.

## Validation

- `npm run test --workspace client`
- `npm run build --workspace client`