### PR TITLE
Keep admin activity out of analytics

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -36,12 +36,6 @@
   </head>
   <body>
     <div id="root"></div>
-    <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
-    <script>
-      window.amplitude.init("f7a70fb74292a0b7b9f5dced71f2931", {
-        autocapture: { elementInteractions: true },
-      });
-    </script>
     <script type="module" src="/src/main.tsx"></script>
   </body>
 </html>

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -193,8 +193,6 @@ export async function logShareAnalyticsEvent({
   playerType?: PlayerType;
   shareUrl?: string;
 }): Promise<void> {
-  window.amplitude?.track("ShareEvent");
-
   const sessionId = getOrCreateSessionId();
   if (!sessionId) {
     return;
@@ -218,26 +216,4 @@ export async function logShareAnalyticsEvent({
   } catch (error) {
     console.warn("Failed to log share analytics event", error);
   }
-}
-
-export function trackAnalysisRunAnalyticsEvent({
-  playerId,
-  playerName,
-  playerType,
-  analysisMode,
-  selectionSource,
-}: {
-  playerId: string;
-  playerName: string;
-  playerType: PlayerType;
-  analysisMode: string;
-  selectionSource: "recent_analyze_again" | "main_ui";
-}): void {
-  window.amplitude?.track("analysis_run", {
-    player_id: playerId,
-    player_name: playerName,
-    player_type: playerType,
-    analysis_mode: analysisMode,
-    selection_source: selectionSource,
-  });
 }

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -3,8 +3,7 @@ import ReactDOM from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import App from "./App";
 import "./styles/global.css";
-import { BrowserRouter, useLocation } from "react-router-dom";
-import { getOrCreateSessionId } from "./api";
+import { BrowserRouter } from "react-router-dom";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -14,43 +13,10 @@ const queryClient = new QueryClient({
   },
 });
 
-function AmplitudePageTracker() {
-  const location = useLocation();
-  const lastTrackedPathRef = React.useRef<string | null>(null);
-  const sessionIdRef = React.useRef<string | null>(null);
-
-  if (sessionIdRef.current === null) {
-    sessionIdRef.current = getOrCreateSessionId();
-  }
-
-  React.useEffect(() => {
-    if (!sessionIdRef.current) {
-      return;
-    }
-    window.amplitude?.setUserId?.(sessionIdRef.current);
-  }, []);
-
-  React.useEffect(() => {
-    const path = `${location.pathname}${location.search}${location.hash}`;
-    if (lastTrackedPathRef.current === path) {
-      return;
-    }
-    lastTrackedPathRef.current = path;
-    const eventProperties: Record<string, unknown> = { path };
-    if (sessionIdRef.current) {
-      eventProperties.session_id = sessionIdRef.current;
-    }
-    window.amplitude?.track("page_view", eventProperties);
-  }, [location.pathname, location.search, location.hash]);
-
-  return null;
-}
-
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
       <BrowserRouter>
-        <AmplitudePageTracker />
         <App />
       </BrowserRouter>
     </QueryClientProvider>

--- a/client/src/pages/SinglePlayerPage.tsx
+++ b/client/src/pages/SinglePlayerPage.tsx
@@ -13,7 +13,6 @@ import {
   fetchPlayerDetail,
   fetchPlayers,
   logShareAnalyticsEvent,
-  trackAnalysisRunAnalyticsEvent,
 } from "../api";
 import type { HitterRecord, PitcherRecord, PlayerType } from "../types";
 import { buildSharePreviewUrl } from "../utils/share";
@@ -179,7 +178,6 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
   const [playerType, setPlayerType] = useState<PlayerType>(initialPlayerType);
   const [searchTerm, setSearchTerm] = useState("");
   const [selectedId, setSelectedId] = useState<string | undefined>(initialPlayerId);
-  const [selectionSource, setSelectionSource] = useState<"recent_analyze_again" | "main_ui">("main_ui");
   const [shareStatus, setShareStatus] = useState<"idle" | "success" | "error">("idle");
   const syncingFromPropsRef = useRef(false);
 
@@ -272,14 +270,7 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
       analysisMode: mode,
     });
 
-    trackAnalysisRunAnalyticsEvent({
-      playerId: selectedId,
-      playerName: detailQuery.data.player.Name,
-      playerType,
-      analysisMode: mode,
-      selectionSource,
-    });
-  }, [analysisData?.analysis, analysisData?.prompt, detailQuery.data, mode, playerType, selectedId, selectionSource]);
+  }, [analysisData?.analysis, analysisData?.prompt, detailQuery.data, mode, playerType, selectedId]);
 
   useEffect(() => {
     if (syncingFromPropsRef.current) {
@@ -338,7 +329,6 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
           onTypeChange={(nextType) => {
             setPlayerType(nextType);
             setSelectedId(undefined);
-            setSelectionSource("main_ui");
             setSearchTerm("");
           }}
           searchTerm={searchTerm}
@@ -351,7 +341,6 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
           players={searchEnabled ? playersQuery.data ?? [] : []}
           selectedId={selectedId}
           onSelect={(playerId) => {
-            setSelectionSource("main_ui");
             setSelectedId(playerId);
           }}
           isLoading={searchEnabled && playersQuery.isLoading}
@@ -359,8 +348,7 @@ function SinglePlayerExperience({ initialPlayerType, initialPlayerId, onStateCha
         <WeeklyTrendsSection
           embedded
           playerType={playerType}
-          onSelectPlayer={({ playerId, playerType: selectedPlayerType, source, analysisMode }) => {
-            setSelectionSource(source);
+          onSelectPlayer={({ playerId, playerType: selectedPlayerType, analysisMode }) => {
             if (selectedPlayerType && selectedPlayerType !== playerType) {
               setPlayerType(selectedPlayerType);
             }

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -1,14 +1,5 @@
 /// <reference types="vite/client" />
 
-type AmplitudeClient = {
-  track: (eventName: string, eventProperties?: Record<string, unknown>) => void;
-  setUserId?: (userId: string) => void;
-};
-
-interface Window {
-  amplitude?: AmplitudeClient;
-}
-
 declare module "*.module.css" {
   const classes: Record<string, string>;
   export default classes;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -265,8 +265,8 @@ export function createServer() {
         useDefaults: true,
         directives: {
           "img-src": ["'self'", "data:", "https://img.mlbstatic.com"],
-          "script-src": ["'self'", "'unsafe-inline'", "https://cdn.amplitude.com"],
-          "connect-src": ["'self'", "https://api2.amplitude.com", "https://api.amplitude.com"],
+          "script-src": ["'self'", "'unsafe-inline'"],
+          "connect-src": ["'self'"],
         },
       },
     })

--- a/server/test/routes.test.ts
+++ b/server/test/routes.test.ts
@@ -147,6 +147,7 @@ describe("McFARLAND API", () => {
   });
 
   afterEach(() => {
+    delete process.env.ADMIN_PASSWORD;
     __setAnalysisCacheStoreForTests(null);
     __setOpenAiChatHandlerForTests(null);
     __setFantasyDecisionHandlerForTests(null);
@@ -504,6 +505,44 @@ describe("McFARLAND API", () => {
       return payload.events[0].event_properties.mode;
     });
     expect(loggedModes).toEqual(["single", "single", "compare"]);
+  });
+
+  it("does not log session starts while admin mode is enabled", async () => {
+    process.env.ADMIN_PASSWORD = "top-secret";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as Response);
+
+    const response = await request(app)
+      .post("/api/sessions?admin=top-secret")
+      .send({ sessionId: "admin-session" });
+
+    expect(response.status).toBe(204);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    delete process.env.ADMIN_PASSWORD;
+  });
+
+  it("does not log analysis events while admin mode is enabled", async () => {
+    process.env.ADMIN_PASSWORD = "top-secret";
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({ ok: true } as Response);
+    __setOpenAiChatHandlerForTests(async (prompt: string, persona: string) => ({
+      prompt,
+      persona,
+      headline: "Admin headline",
+      analysis: "Admin analysis",
+      cached: false,
+    }));
+
+    const { body: listBody } = await request(app).get("/api/players").query({ type: "hitter", q: "Judge" });
+    const hitter = listBody.players[0];
+    const response = await request(app)
+      .post("/api/analyze?admin=top-secret")
+      .set("x-session-id", "admin-analysis")
+      .send({ playerId: hitter.id, playerType: "hitter", analysisMode: "gen_z" });
+
+    expect(response.status).toBe(200);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(fetchSpy).not.toHaveBeenCalled();
+    delete process.env.ADMIN_PASSWORD;
   });
 
   it("prunes stale analysis cache rows after successful writes", async () => {


### PR DESCRIPTION
## What changes for users

Analytics now reflect server-confirmed product events only, so admin activity and browser-side events no longer pollute Amplitude.

## Implementation notes

- Removes the browser Amplitude SDK, page tracking, share tracking, and client-side analysis tracking.
- Keeps analytics forwarding on the server through the existing session, share, and analysis endpoints.
- Tightens the client CSP so the browser no longer permits Amplitude script or connect origins.
- Adds coverage proving admin mode suppresses `session_started` and `analysis_logged`.

## Validation

- `npm run test --workspace server`
- `npm run test --workspace client`
- `npm run build --workspace client`