### PR TITLE
Make plain site shares image-free

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -11,27 +11,6 @@
       name="description"
       content="Advanced baseball analysis in plain English. Compare players, explore trends, and share insights."
     />
-    <meta property="og:type" content="website" />
-    <meta property="og:site_name" content="McFARLAND" />
-    <meta property="og:title" content="McFARLAND | Advanced Baseball Analysis" />
-    <meta
-      property="og:description"
-      content="Advanced baseball analysis in plain English. Compare players, explore trends, and share insights."
-    />
-    <meta
-      property="og:image"
-      content="https://img.mlbstatic.com/mlb-photos/image/upload/w_1200,d_people:generic:headshot:silo:current.png,q_auto:best,f_auto/v1/people/0/headshot/67/current"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="McFARLAND | Advanced Baseball Analysis" />
-    <meta
-      name="twitter:description"
-      content="Advanced baseball analysis in plain English. Compare players, explore trends, and share insights."
-    />
-    <meta
-      name="twitter:image"
-      content="https://img.mlbstatic.com/mlb-photos/image/upload/w_1200,d_people:generic:headshot:silo:current.png,q_auto:best,f_auto/v1/people/0/headshot/67/current"
-    />
     <title>McFARLAND Player Analysis</title>
   </head>
   <body>

--- a/server/test/routes.test.ts
+++ b/server/test/routes.test.ts
@@ -838,6 +838,9 @@ describe("McFARLAND API", () => {
     expect(response.headers["content-type"]).toContain("text/html");
     expect(response.text).toContain("og:title");
     expect(response.text).toContain("twitter:title");
+    expect(response.text).toContain("og:image");
+    expect(response.text).toContain("twitter:image");
+    expect(response.text).toContain("img.mlbstatic.com");
     expect(response.text).toContain("Judge");
     expect(response.text).toContain("/?mode=single");
   });
@@ -865,6 +868,18 @@ describe("McFARLAND API", () => {
     expect(response.status).toBe(200);
     expect(response.text).toContain('property="og:title" content="Judge keeps forcing the issue | McFARLAND"');
     expect(response.text).toContain('name="twitter:title" content="Judge keeps forcing the issue | McFARLAND"');
+  });
+
+  it("does not include image metadata for plain app URL shares", async () => {
+    const response = await request(app).get("/");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["content-type"]).toContain("text/html");
+    expect(response.text).toContain('property="og:title" content="McFARLAND | Advanced Baseball Analysis"');
+    expect(response.text).toContain('name="twitter:card" content="summary"');
+    expect(response.text).not.toContain('property="og:image"');
+    expect(response.text).not.toContain('name="twitter:image"');
+    expect(response.text).not.toContain("generic:headshot");
   });
 
   it("injects OG tags into SPA HTML responses", async () => {


### PR DESCRIPTION
## What changes for users

Sharing `mcfarlandapp.com` now produces a clean generic McFARLAND link preview without the blank generic MLB headshot image. Player analysis share links still show the player/headline preview with the player headshot.

## Implementation notes

- Removes static Open Graph/Twitter image metadata from the base HTML template.
- Keeps server-injected image metadata for player and comparison share contexts.
- Adds regression coverage for plain app URL shares and player share previews.

## Validation

- `npm run build --workspace client`
- `npm run test --workspace server`
- `npm run test --workspace client`