### PR TITLE
Keep AI player analysis on a supported OpenAI model

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ The Express server serves the built React app at `http://localhost:3000`.
 | Name | Purpose | Default |
 | ---- | ------- | ------- |
 | `OPENAI_API_KEY` | Enables OpenAI-generated headline and analysis responses. | unset |
+| `OPENAI_MODEL` | Model used for OpenAI-generated headline and analysis responses. | `gpt-5.4-mini` |
 | `DATABASE_URL` | Enables Postgres-backed analysis cache and weekly trend storage. | unset |
 | `AMPLITUDE_API_KEY` | Sends analytics events to a specific Amplitude project. | built-in project key |
 | `ADMIN_PASSWORD` | Enables admin mode protection for social assistant endpoints. | unset |

--- a/server/src/openai.ts
+++ b/server/src/openai.ts
@@ -36,6 +36,7 @@ let testChatHandler: ChatHandler | null = null;
 let testFantasyDecisionHandler: FantasyDecisionHandler | null = null;
 const uncacheableResponses = new WeakSet<OpenAIResponse>();
 const uncacheableFantasyResponses = new WeakSet<FantasyDecisionResponse>();
+const DEFAULT_OPENAI_MODEL = "gpt-5.4-mini";
 
 export function buildStructuredAnalysisPrompt(prompt: string, persona: string, mode: AnalysisMode): string {
   const modeSpecificInstructions =
@@ -185,6 +186,7 @@ function buildFallbackHeadline(analysis: string): string {
 }
 
 async function runChatCompletion(apiKey: string, prompt: string): Promise<string> {
+  const model = process.env.OPENAI_MODEL?.trim() || DEFAULT_OPENAI_MODEL;
   const response = await fetch("https://api.openai.com/v1/chat/completions", {
     method: "POST",
     headers: {
@@ -192,7 +194,7 @@ async function runChatCompletion(apiKey: string, prompt: string): Promise<string
       "Content-Type": "application/json",
     },
     body: JSON.stringify({
-      model: "gpt-5-mini",
+      model,
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## What changed
- Updated the default OpenAI model for generated player analysis from `gpt-5-mini` to `gpt-5.4-mini`.
- Added an `OPENAI_MODEL` environment override so future model swaps can happen without a code change.
- Documented the new model environment variable in the README.

## Why it matters
Player analysis stays on OpenAI's recommended replacement before the dated GPT-5 mini snapshot shuts down on December 11, 2026, reducing the risk of analysis failures for users.

## Validation
- `npm run test --workspace server`